### PR TITLE
Multi-Host config support

### DIFF
--- a/Posh-IBWAPI/Private/Initialize-CallVars.ps1
+++ b/Posh-IBWAPI/Private/Initialize-CallVars.ps1
@@ -21,16 +21,17 @@ function Initialize-CallVars
     # parameters from the function call. Explicit parameters always
     # override saved module variables.
 
-    # make sure we've got some basics setup
+    # Resolve the host target first so we know which saved config set to use
     if (!$script:CurrentHost) { $script:CurrentHost = '' }
-    if (!$script:Config) { $script:Config = @{$script:CurrentHost=@{WAPIHost=$script:CurrentHost}} }
-    $cfg = $script:Config.$script:CurrentHost
-
-    # let the saved module variables pass through if explicit the
-    # explicit parameters are not defined
     if ([String]::IsNullOrWhiteSpace($WAPIHost)) {
-        $WAPIHost = $cfg.WAPIHost
+        $WAPIHost = $script:CurrentHost
     }
+
+    # Make sure we have at least an empty config defined for this host
+    if (!$script:Config) { $script:Config = @{} }
+    if (!$script:Config.$WAPIHost) { $script:Config.$WAPIHost = @{WAPIHost=$WAPIHost} }
+    $cfg = $script:Config.$WAPIHost
+
     if ([String]::IsNullOrWhiteSpace($WAPIVersion)) {
         $WAPIVersion = $cfg.WAPIVersion
     }

--- a/Posh-IBWAPI/Private/Initialize-CallVars.ps1
+++ b/Posh-IBWAPI/Private/Initialize-CallVars.ps1
@@ -21,13 +21,18 @@ function Initialize-CallVars
     # parameters from the function call. Explicit parameters always
     # override saved module variables.
 
+    # make sure we've got some basics setup
+    if (!$script:CurrentHost) { $script:CurrentHost = '' }
+    if (!$script:Config) { $script:Config = @{$script:CurrentHost=@{WAPIHost=$script:CurrentHost}} }
+    $cfg = $script:Config.$script:CurrentHost
+
     # let the saved module variables pass through if explicit the
     # explicit parameters are not defined
     if ([String]::IsNullOrWhiteSpace($WAPIHost)) {
-        $WAPIHost = $script:WAPIHost
+        $WAPIHost = $cfg.WAPIHost
     }
     if ([String]::IsNullOrWhiteSpace($WAPIVersion)) {
-        $WAPIVersion = $script:WAPIVersion
+        $WAPIVersion = $cfg.WAPIVersion
     }
     else {
         # sanity check the version string
@@ -41,10 +46,10 @@ function Initialize-CallVars
         [Version]$WAPIVersion | Out-Null
     }
     if (!$Credential) {
-        $Credential = $script:Credential
+        $Credential = $cfg.Credential
     }
     if (!$WebSession) {
-        $WebSession = $script:WebSession
+        $WebSession = $cfg.WebSession
     }
 
     # build the APIBase URL
@@ -77,7 +82,7 @@ function Initialize-CallVars
         $certIgnore = $IgnoreCertificateValidation
     }
     else {
-        $certIgnore = $script:IgnoreCertificateValidation
+        $certIgnore = $cfg.IgnoreCertificateValidation
     }
 
     # return the results

--- a/Posh-IBWAPI/Public/Get-IBWAPIConfig.ps1
+++ b/Posh-IBWAPI/Public/Get-IBWAPIConfig.ps1
@@ -1,15 +1,31 @@
 function Get-IBWAPIConfig
 {
     [CmdletBinding()]
-    param()
+    param(
+        [switch]$List
+    )
 
-    [PSCustomObject]@{
-        WAPIHost=[string]$script:WAPIHost;
-        WAPIVersion=[string]$script:WAPIVersion;
-        Credential=[PSCredential]$script:Credential;
-        WebSession=[Microsoft.PowerShell.Commands.WebRequestSession]$script:WebSession;
-        IgnoreCertificateValidation=$script:IgnoreCertificateValidation;
+    if ($List -and $script:Config) {
+        # list all configs
+        foreach ($hostConfig in $script:Config.Values) {
+            [PSCustomObject]$hostConfig
+        }
     }
+    elseif ($script:Config -and $script:CurrentHost) {
+        # show the current config
+        [PSCustomObject]$script:Config.$script:CurrentHost
+    }
+    else {
+        # show empty config
+        [PSCustomObject]@{
+            WAPIHost=$null;
+            WAPIVersion=$null;
+            Credential=$null;
+            WebSession=$null;
+            IgnoreCertificateValidation=$null;
+        }
+    }
+
 
 
 
@@ -21,13 +37,22 @@ function Get-IBWAPIConfig
     .DESCRIPTION
         The configuration values returned by this function will automatically be used by related function calls to the Infoblox API unless they are overridden by the function's own parameters.
 
+    .PARAMETER List
+        If set, list all config sets currently stored. Otherwise, just list the currently active set.
+
     .OUTPUTS
-        A PSCustomObject that contains all of the configuration values for this module.
+        [PSCustomObject]
+        One or more config sets for this module.
 
     .EXAMPLE
         Get-IBWAPIConfig
 
         Get the current configuration values.
+
+    .EXAMPLE
+        Get-IBWAPIConfig -List
+
+        Get all sets of configuration values.
 
     .LINK
         Project: https://github.com/rmbolger/Posh-IBWAPI

--- a/Posh-IBWAPI/Public/Get-IBWAPIConfig.ps1
+++ b/Posh-IBWAPI/Public/Get-IBWAPIConfig.ps1
@@ -2,18 +2,34 @@ function Get-IBWAPIConfig
 {
     [CmdletBinding()]
     param(
+        [string]$WAPIHost,
         [switch]$List
     )
 
     if ($List -and $script:Config) {
         # list all configs
         foreach ($hostConfig in $script:Config.Values) {
-            [PSCustomObject]$hostConfig
+            [PSCustomObject]$hostConfig | Select-Object WAPIHost,WAPIVersion,Credential,WebSession,IgnoreCertificateValidation
+        }
+    }
+    elseif ($script:Config -and $WAPIHost) {
+        if ($script:Config.$WAPIHost) {
+            # show the specified config
+            [PSCustomObject]$script:Config.$WAPIHost | Select-Object WAPIHost,WAPIVersion,Credential,WebSession,IgnoreCertificateValidation
+        } else {
+            # show empty config
+            [PSCustomObject]@{
+                WAPIHost=$null;
+                WAPIVersion=$null;
+                Credential=$null;
+                WebSession=$null;
+                IgnoreCertificateValidation=$null;
+            }
         }
     }
     elseif ($script:Config -and $script:CurrentHost) {
         # show the current config
-        [PSCustomObject]$script:Config.$script:CurrentHost
+        [PSCustomObject]$script:Config.$script:CurrentHost | Select-Object WAPIHost,WAPIVersion,Credential,WebSession,IgnoreCertificateValidation
     }
     else {
         # show empty config
@@ -35,7 +51,12 @@ function Get-IBWAPIConfig
         Get the current set of configuration values for this module.
 
     .DESCRIPTION
-        The configuration values returned by this function will automatically be used by related function calls to the Infoblox API unless they are overridden by the function's own parameters.
+        When calling this function with no parameters, the currently active set of config values will be returned. These values will be used by related function calls to the Infoblox API unless they are overridden by the function's own parameters.
+
+        When called with -WAPIHost, the set of config values for that host will be returned. When called with -List, all sets of config values will be returned.
+
+    .PARAMETER WAPIHost
+        The fully qualified DNS name or IP address of the Infoblox WAPI endpoint (usually the grid master).
 
     .PARAMETER List
         If set, list all config sets currently stored. Otherwise, just list the currently active set.

--- a/Posh-IBWAPI/Public/Set-IBWAPIConfig.ps1
+++ b/Posh-IBWAPI/Public/Set-IBWAPIConfig.ps1
@@ -9,8 +9,7 @@ function Set-IBWAPIConfig
         [PSCredential]$Credential,
         [Alias('session')]
         [Microsoft.PowerShell.Commands.WebRequestSession]$WebSession,
-        [switch]$IgnoreCertificateValidation,
-        [switch]$ForAll
+        [switch]$IgnoreCertificateValidation
     )
 
     # We want to allow callers to save some of the normally tedious parameters
@@ -22,12 +21,8 @@ function Set-IBWAPIConfig
     # to the callers of module functions.
 
     # make sure we've got some basics setup
-    if (!$script:CurrentHost) {
-        $script:CurrentHost = ''
-    }
-    if (!$script:Config) {
-        $script:Config = @{}
-    }
+    if (!$script:CurrentHost) { $script:CurrentHost = '' }
+    if (!$script:Config) { $script:Config = @{$script:CurrentHost=@{WAPIHost=$script:CurrentHost}} }
 
     # deal with hostname
     if (![String]::IsNullOrWhiteSpace($WAPIHost)) {
@@ -36,8 +31,10 @@ function Set-IBWAPIConfig
         # initialize a hashtable for this host if it doesn't exist
         if (!$script:Config.$WAPIHost) {
             $cfgNew = $script:Config.$WAPIHost = @{}
+            $cfgNew.WAPIHost = $WAPIHost
             if ($cfgOld) {
                 # copy some of the values from the old host
+                Write-Verbose "Copying config from $($script:CurrentHost)"
                 if ($cfgOld.WAPIVersion) { $cfgNew.WAPIVersion = $cfgOld.WAPIVersion }
                 if ($cfgOld.Credential) { $cfgNew.Credential = $cfgOld.Credential }
                 if ($cfgOld.WebSession) { $cfgNew.WebSession = $cfgOld.WebSession }
@@ -61,31 +58,31 @@ function Set-IBWAPIConfig
 
     if ($WebSession) {
         Write-Verbose "Saving new WebSession with Credential for $($WebSession.Credentials.UserName)"
-        $script:WebSession = $WebSession
+        $cfg.WebSession = $WebSession
     }
 
     if ($Credential) {
         Write-Verbose "Saving Credential for $($Credential.UserName)"
-        $script:Credential = $Credential
+        $cfg.Credential = $Credential
 
-        if (!$script:WebSession) {
+        if (!$cfg.WebSession) {
             # Configure an empty WebSession if we don't have one already
             Write-Verbose "Creating empty WebSession with Credential for $($Credential.UserName)"
             $session = New-Object Microsoft.PowerShell.Commands.WebRequestSession
             $session.Credentials = $Credential.GetNetworkCredential()
-            $script:WebSession = $session
+            $cfg.WebSession = $session
         }
         else {
             # Update the credential in our existing WebSession
             Write-Verbose "Updating existing WebSession with Credential for $($Credential.UserName)"
-            ($script:WebSession).Credentials = $Credential.GetNetworkCredential()
+            $cfg.WebSession.Credentials = $Credential.GetNetworkCredential()
         }
     }
 
     # deal with setting IgnoreCertificateValidation
     if ($PSBoundParameters.ContainsKey('IgnoreCertificateValidation')) {
         Write-Verbose "Saving IgnoreCertificateValidation $IgnoreCertificateValidation"
-        $script:IgnoreCertificateValidation = $IgnoreCertificateValidation
+        $cfg.IgnoreCertificateValidation = $IgnoreCertificateValidation
     }
 
     if (![String]::IsNullOrWhiteSpace($WAPIVersion)) {
@@ -96,7 +93,7 @@ function Set-IBWAPIConfig
         if ($WAPIVersion -eq 'latest') {
             # Query the grid master schema for the list of supported versions
             Write-Verbose "Querying schema for supported versions"
-            $versions = (Invoke-IBWAPI -Uri "https://$($script:WAPIHost)/wapi/v1.0/?_schema" -WebSession $script:WebSession -IgnoreCertificateValidation:($script:IgnoreCertificateValidation)).supported_versions
+            $versions = (Invoke-IBWAPI -Uri "https://$($cfg.WAPIHost)/wapi/v1.0/?_schema" -WebSession $cfg.WebSession -IgnoreCertificateValidation:($cfg.IgnoreCertificateValidation)).supported_versions
 
             # Historically, these are returned in order. But just in case they aren't, we'll
             # explicitly sort them via the [Version] cast which is an easy way to make sure you
@@ -104,8 +101,8 @@ function Set-IBWAPIConfig
             $versions = $versions | Sort-Object @{E={[Version]$_}}
 
             # set the most recent (last) one in the sorted list
-            $script:WAPIVersion = $versions | Select-Object -Last 1
-            Write-Verbose "Saved WAPIVersion as $($script:WAPIVersion)"
+            $cfg.WAPIVersion = $versions | Select-Object -Last 1
+            Write-Verbose "Saved WAPIVersion as $($cfg.WAPIVersion)"
         }
         else {
             # Users familiar with the Infoblox WAPI might include a 'v' in their version
@@ -117,7 +114,7 @@ function Set-IBWAPIConfig
 
             # validate it can actually be parsed by the Version object
             if ([Version]$WAPIVersion) {
-                $script:WAPIVersion = $WAPIVersion
+                $cfg.WAPIVersion = $WAPIVersion
             }
 
             # WARNING: Both the sorting and the [Version] validation may break

--- a/Posh-IBWAPI/Public/Set-IBWAPIConfig.ps1
+++ b/Posh-IBWAPI/Public/Set-IBWAPIConfig.ps1
@@ -22,7 +22,8 @@ function Set-IBWAPIConfig
 
     # make sure we've got some basics setup
     if (!$script:CurrentHost) { $script:CurrentHost = '' }
-    if (!$script:Config) { $script:Config = @{$script:CurrentHost=@{WAPIHost=$script:CurrentHost}} }
+    if (!$script:Config) { $script:Config = @{} }
+    if (!$script:Config.$script:CurrentHost) { $script:Config.$script:CurrentHost = @{WAPIHost=$script:CurrentHost} }
 
     # deal with hostname
     if (![String]::IsNullOrWhiteSpace($WAPIHost)) {
@@ -30,8 +31,7 @@ function Set-IBWAPIConfig
 
         # initialize a hashtable for this host if it doesn't exist
         if (!$script:Config.$WAPIHost) {
-            $cfgNew = $script:Config.$WAPIHost = @{}
-            $cfgNew.WAPIHost = $WAPIHost
+            $cfgNew = $script:Config.$WAPIHost = @{WAPIHost=$WAPIHost}
             if ($cfgOld) {
                 # copy some of the values from the old host
                 Write-Verbose "Copying config from $($script:CurrentHost)"

--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ This PowerShell module makes it easier to automate Infoblox WAPI requests and fu
 - Pipeline support so you can do things like pass the results from `Get-IBObject` directly to `Remove-IBObject`.
 - Optionally ignore certificate validation errors.
 - Save common connection parameters per-session with `Set-IBWAPIConfig` so you don't need to pass them to every function call.
+- In multi-grid or multi-host environments, connection parameters can be saved separately for each WAPI host.
 
 # Install
 


### PR DESCRIPTION
If you want to use this module against multiple WAPI endpoints, you currently have to either keep resetting the config values with `Set-IBWAPIConfig` or skip it and just pass the config values directly on each call. Both methods are annoying.

This change adds the ability for `Set-IBWAPIConfig` to support saving a config set per `WAPIHost`. Under the hood it's just a hashtable of config sets using WAPIHost as the key.  Calling `Set-IBWAPIConfig` with just a `-WAPIHost` param will switch the currently active set.  Adding additional parameters will switch and set those values. With no `-WAPIHost` param, it will just modify the values of the currently active set.