### PR TITLE
Added Get-IBSchema

### DIFF
--- a/Posh-IBWAPI/Posh-IBWAPI.psd1
+++ b/Posh-IBWAPI/Posh-IBWAPI.psd1
@@ -71,6 +71,7 @@ FormatsToProcess = 'Posh-IBWAPI.Format.ps1xml'
 # Functions to export from this module, for best performance, do not use wildcards and do not delete the entry, use an empty array if there are no functions to export.
 FunctionsToExport = @(
     'Get-IBObject',
+    'Get-IBSchema',
     'Get-IBWAPIConfig',
     'Invoke-IBFunction',
     'Invoke-IBWAPI',

--- a/Posh-IBWAPI/Private/Format-Columns.ps1
+++ b/Posh-IBWAPI/Private/Format-Columns.ps1
@@ -124,7 +124,9 @@ function Format-Columns {
         Name: Get-Columns
         Author: stej, http://twitter.com/stejcz
         Site: http://www.leporelo.eu/blog.aspx?id=powershell-formatting-format-wide-rotated-to-format-columns
-        Lastedit: 2017-04-24
+        Lastedit: 2017-09-11
+        Version 0.4 - 2017-09-11
+        - removed color support and changed output from Write-Host to Write-Output
         Version 0.3 - 2017-04-24
         - added ForegroundColor and BackgroundColor
         Version 0.2 - 2010-01-14

--- a/Posh-IBWAPI/Private/Format-Columns.ps1
+++ b/Posh-IBWAPI/Private/Format-Columns.ps1
@@ -1,0 +1,138 @@
+function Format-Columns {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory=$true,ValueFromPipeline=$true)]
+        [PsObject[]]$InputObject,
+        [Object]$Property,
+        [int]$Column,
+        [int]$MaxColumn,
+        [switch]$Autosize,
+        [System.ConsoleColor]$ForegroundColor,
+        [System.ConsoleColor]$BackgroundColor
+    )
+    
+    Begin   { $values = @() }
+    Process { $values += $InputObject }
+    End {
+        function ProcessValues {
+            $ret = $values
+            $p = $Property
+            if ($p -is [Hashtable]) {
+                $exp = $p.Expression
+                if ($exp) {
+                    if ($exp -is [string])          { $ret = $ret | % { $_.($exp) } }
+                    elseif ($exp -is [scriptblock]) { $ret = $ret | % { & $exp $_} }
+                    else                            { throw 'Invalid Expression value' }
+                }
+                if ($p.FormatString) {
+                    if ($p.FormatString -is [string]) {    $ret = $ret | % { $p.FormatString -f $_ } }
+                    else {                              throw 'Invalid format string' }
+                }
+            }
+            elseif ($p -is [scriptblock]) { $ret = $ret | % { & $p $_} }
+            elseif ($p -is [string]) {      $ret = $ret | % { $_.$p } }
+            elseif ($p -ne $null) {         throw 'Invalid -property type' }
+            # in case there were some numbers, objects, etc., convert them to string
+            $ret | % { $_.ToString() }
+        }
+        function Base($i) { [Math]::Floor($i) }
+        function Max($i1, $i2) {  [Math]::Max($i1, $i2) }
+        if (!$Column) { $Autosize = $true }
+        $values = ProcessValues
+        
+        $valuesCount = @($values).Count
+        if ($valuesCount -eq 1) {
+            Write-Host $values -ForegroundColor $ForegroundColor -BackgroundColor $BackgroundColor
+            return
+        }
+        
+        # from some reason the console host doesn't use the last column and writes to new line
+        $consoleWidth          = $host.ui.RawUI.maxWindowSize.Width - 1
+        $gutterWidth = 2
+            
+        # get length of the longest string
+        $values | % -Begin { [int]$maxLength = -1 } -Process { $maxLength = Max $maxLength $_.Length }
+        
+        # get count of columns if not provided
+        if ($Autosize) {
+            $Column         = Max (Base ($consoleWidth/($maxLength+$gutterWidth))) 1
+            $remainingSpace = $consoleWidth - $Column*($maxLength+$gutterWidth);
+            if ($remainingSpace -ge $maxLength) { 
+                $Column++ 
+            }
+            if ($MaxColumn -and $MaxColumn -lt $Column) {
+                $Column = $MaxColumn
+            }
+        }
+        $countOfRows       = [Math]::Ceiling($valuesCount / $Column)
+        $maxPossibleLength = Base ($consoleWidth / $Column)
+        
+        # cut too long values, considers count of columns and space between them
+        $values = $values | % {
+            if ($_.length -gt $maxPossibleLength) { $_.Remove($maxPossibleLength-2) + '..' }
+            else { $_ }
+        }
+        
+        #add empty values so that the values fill rectangle (2 dim array) without space
+        if ($Column -gt 1) {
+            $values += (@('') * ($countOfRows*$Column - $valuesCount))
+        }
+        # in case there is only one item, make it array
+        $values = @($values)
+        <#
+        now we have values like this: 1, 2, 3, 4, 5, 6, 7, ''
+        and we want to display them like this:
+        1 3 5 7
+        2 4 6 ''
+        #>
+        
+        $formatString = (1..$Column | %{ "{$($_-1),-$maxPossibleLength}" }) -join ''
+
+        1..$countOfRows | % {
+            $r    = $_-1
+            $line = @(1..$Column | %{ $values[$r + ($_-1)*$countOfRows]} )
+            Write-Host "$($formatString -f $line)".PadRight($consoleWidth,' ') -BackgroundColor $BackgroundColor -ForegroundColor $ForegroundColor
+        }
+    }
+
+    <#
+    .SYNOPSIS
+        Formats incoming data to columns.
+    .DESCRIPTION
+        It works similarly as Format-Wide but it works vertically. Format-Wide outputs the data row by row, but Format-Columns outputs them column by column.
+    .PARAMETER Property
+        Name of property to get from the object.
+        It may be 
+            -- string - name of property.
+            -- scriptblock
+            -- hashtable with keys 'Expression' (value is string=property name or scriptblock)
+                and 'FormatString' (used in -f operator)
+    .PARAMETER Column
+        Count of columns
+    .PARAMETER Autosize
+        Determines if count of columns is computed automatically.
+    .PARAMETER MaxColumn
+        Maximal count of columns if Autosize is specified
+    .PARAMETER InputObject
+        Data to display
+    .EXAMPLE
+        1..150 | Format-Columns -Autosize
+    .EXAMPLE 
+        Format-Columns -Col 3 -Input 1..130
+    .EXAMPLE
+        Get-Process | Format-Columns -prop @{Expression='Handles'; FormatString='{0:00000}'} -auto
+    .EXAMPLE
+        Get-Process | Format-Columns -prop {$_.Handles} -auto
+    .NOTES
+        Name: Get-Columns
+        Author: stej, http://twitter.com/stejcz
+        Site: http://www.leporelo.eu/blog.aspx?id=powershell-formatting-format-wide-rotated-to-format-columns
+        Lastedit: 2017-04-24
+        Version 0.3 - 2017-04-24
+        - added ForegroundColor and BackgroundColor
+        Version 0.2 - 2010-01-14
+        - added MaxColumn
+        - fixed bug - displaying collection of 1 item was incorrect
+        Version 0.1 - 2010-01-06
+    #>
+}

--- a/Posh-IBWAPI/Private/Format-Columns.ps1
+++ b/Posh-IBWAPI/Private/Format-Columns.ps1
@@ -39,10 +39,15 @@ function Format-Columns {
         function Max($i1, $i2) {  [Math]::Max($i1, $i2) }
         if (!$Column) { $Autosize = $true }
         $values = ProcessValues
+
+        # splat the colors in case they weren't specified
+        $colors = @{}
+        if ($ForegroundColor) { $colors.ForegroundColor = $ForegroundColor }
+        if ($BackgroundColor) { $colors.BackgroundColor = $BackgroundColor }
         
         $valuesCount = @($values).Count
         if ($valuesCount -eq 1) {
-            Write-Host $values -ForegroundColor $ForegroundColor -BackgroundColor $BackgroundColor
+            Write-Host $values @colors
             return
         }
         
@@ -91,7 +96,7 @@ function Format-Columns {
         1..$countOfRows | % {
             $r    = $_-1
             $line = @(1..$Column | %{ $values[$r + ($_-1)*$countOfRows]} )
-            Write-Host "$($formatString -f $line)".PadRight($consoleWidth,' ') -BackgroundColor $BackgroundColor -ForegroundColor $ForegroundColor
+            Write-Host "$($formatString -f $line)".PadRight($consoleWidth,' ') @colors
         }
     }
 

--- a/Posh-IBWAPI/Private/Format-Columns.ps1
+++ b/Posh-IBWAPI/Private/Format-Columns.ps1
@@ -6,9 +6,7 @@ function Format-Columns {
         [Object]$Property,
         [int]$Column,
         [int]$MaxColumn,
-        [switch]$Autosize,
-        [System.ConsoleColor]$ForegroundColor,
-        [System.ConsoleColor]$BackgroundColor
+        [switch]$Autosize
     )
     
     Begin   { $values = @() }
@@ -40,15 +38,9 @@ function Format-Columns {
         if (!$Column) { $Autosize = $true }
         $values = ProcessValues
 
-        # splat the colors in case they weren't specified
-        $colors = @{}
-        if ($ForegroundColor) { $colors.ForegroundColor = $ForegroundColor }
-        if ($BackgroundColor) { $colors.BackgroundColor = $BackgroundColor }
-        
         $valuesCount = @($values).Count
         if ($valuesCount -eq 1) {
-            Write-Host $values @colors
-            return
+            return $values
         }
         
         # from some reason the console host doesn't use the last column and writes to new line
@@ -96,7 +88,7 @@ function Format-Columns {
         1..$countOfRows | % {
             $r    = $_-1
             $line = @(1..$Column | %{ $values[$r + ($_-1)*$countOfRows]} )
-            Write-Host "$($formatString -f $line)".PadRight($consoleWidth,' ') @colors
+            Write-Output "$($formatString -f $line)".PadRight($consoleWidth,' ')
         }
     }
 

--- a/Posh-IBWAPI/Private/Word-Wrap.ps1
+++ b/Posh-IBWAPI/Private/Word-Wrap.ps1
@@ -1,0 +1,87 @@
+function Word-Wrap {
+    [CmdletBinding()]
+    Param(
+        [Parameter(Mandatory=$True,ValueFromPipeline=$True,ValueFromPipelineByPropertyName=$True)]
+        [string[]]$Text,
+        [int]$MaxWidth=$Host.UI.RawUI.BufferSize.Width,
+        [int]$Indent,
+        [switch]$PadMax
+    )
+
+    Process {
+
+        # setup our return array
+        $retLines = @()
+
+        if ($Indent) { $MaxWidth -= $Indent }
+
+        foreach ($origString in $Text) {
+            Write-Verbose "Top length $($origString.Length)"
+
+            # because we may be indenting, we need to care about embedded NewLine
+            # characters and insert the indent for each one
+            foreach ($line in $origString.Split([Environment]::NewLine)) {
+                Write-Verbose "new outer line"
+
+                while ($line.Length -gt $MaxWidth) {
+                    $newLine = ''
+
+                    # copy a maxWidth+1 chunk
+                    $chunk = $line.Substring(0,$MaxWidth+1)
+                    $lastSpaceIndex = $chunk.LastIndexOf(' ')
+                    Write-Verbose "chunk length $($chunk.length) and space index $lastSpaceIndex"
+
+                    if ($lastSpaceIndex -le 0) {
+                        # no natural spaces to split, so just split on max width
+                        $lastSpaceIndex = $MaxWidth
+                    }
+
+                    # grab the piece we need, pad and indent if necessary,
+                    # and add it to the output
+                    $newLine = $chunk.Substring(0,$lastSpaceIndex)
+                    if ($PadMax) { $newLine = $newLine.PadRight($MaxWidth) }
+                    if ($Indent) { $newLine = "$(' ' * $Indent)$newLine" }
+                    $retLines += $newLine
+
+                    # remove the piece from current line
+                    $line = $line.Substring($lastSpaceIndex + 1)
+                }
+
+                Write-Verbose "last chunk length $($line.length)"
+                # pad and indent if necessary and add the last piece to the output
+                if ($PadMax) { $line = $line.PadRight($MaxWidth) }
+                if ($Indent) { $line = "$(' ' * $Indent)$line" }
+                $retLines += $line
+            }
+
+        }
+        $retLines
+    }
+
+    <#
+    .SYNOPSIS
+        Attempts to wrap a string or array of strings at the word boundary given a maximum width.
+
+    .PARAMETER Text
+        A string or an array of strings.
+
+    .PARAMETER MaxWidth
+        The maximum characters per line.
+
+    .PARAMETER Indent
+        The number of characters to indent each line.
+
+    .PARAMETER PadMax
+        If set, each line will be padded with spaces on the right with enough to reach -MaxWidth.
+
+    .EXAMPLE
+        Word-Wrap $longString
+
+        Word wrap $longString to the max console width.
+
+    .EXAMPLE
+        $longString | Word-Wrap -max 100 -indent 4 -pad
+
+        Word wrap $longString to 100 characters with a 4 character indent and right padding.
+    #>
+}

--- a/Posh-IBWAPI/Private/Word-Wrap.ps1
+++ b/Posh-IBWAPI/Private/Word-Wrap.ps1
@@ -16,12 +16,12 @@ function Word-Wrap {
         if ($Indent) { $MaxWidth -= $Indent }
 
         foreach ($origString in $Text) {
-            Write-Verbose "Top length $($origString.Length)"
+            Write-Debug "Top length $($origString.Length)"
 
             # because we may be indenting, we need to care about embedded NewLine
             # characters and insert the indent for each one
             foreach ($line in $origString.Split([Environment]::NewLine)) {
-                Write-Verbose "new outer line"
+                Write-Debug "new outer line"
 
                 while ($line.Length -gt $MaxWidth) {
                     $newLine = ''
@@ -29,7 +29,7 @@ function Word-Wrap {
                     # copy a maxWidth+1 chunk
                     $chunk = $line.Substring(0,$MaxWidth+1)
                     $lastSpaceIndex = $chunk.LastIndexOf(' ')
-                    Write-Verbose "chunk length $($chunk.length) and space index $lastSpaceIndex"
+                    Write-Debug "chunk length $($chunk.length) and space index $lastSpaceIndex"
 
                     if ($lastSpaceIndex -le 0) {
                         # no natural spaces to split, so just split on max width
@@ -47,7 +47,7 @@ function Word-Wrap {
                     $line = $line.Substring($lastSpaceIndex + 1)
                 }
 
-                Write-Verbose "last chunk length $($line.length)"
+                Write-Debug "last chunk length $($line.length)"
                 # pad and indent if necessary and add the last piece to the output
                 if ($PadMax) { $line = $line.PadRight($MaxWidth) }
                 if ($Indent) { $line = "$(' ' * $Indent)$line" }

--- a/Posh-IBWAPI/Public/Get-IBSchema.ps1
+++ b/Posh-IBWAPI/Public/Get-IBSchema.ps1
@@ -1,0 +1,294 @@
+function Get-IBSchema {
+    [CmdletBinding()]
+    param(
+        [Alias('type')]
+        [string]$ObjectType,
+        [switch]$Raw,
+        [string[]]$Fields,
+        [string[]]$Operations,
+        [string[]]$Functions,
+        [Alias('host')]
+        [string]$WAPIHost,
+        [Alias('version')]
+        [string]$WAPIVersion,
+        [PSCredential]$Credential,
+        [Alias('session')]
+        [Microsoft.PowerShell.Commands.WebRequestSession]$WebSession,
+        [switch]$IgnoreCertificateValidation
+    )
+
+    # grab the variables we'll be using for our REST calls
+    $cfg = Initialize-CallVars @PSBoundParameters
+    $APIBase = Base @cfg
+    $cfg.Remove('WAPIHost') | Out-Null
+    $cfg.Remove('WAPIVersion') | Out-Null
+
+    # As of WAPI 2.6 (NIOS 8.1), schema queries get a lot more helpful with the addition of
+    # _schema_version, _schema_searchable, and _get_doc. The odd thing is that those fields
+    # are even available if you specify old WAPI versions. But if you're *actually* on an
+    # old WAPI version, they generate an error.
+    #
+    # We want to give people as much information as possible. So instead of conditionally
+    # using the additional schema options if the requested WAPI version supports it, we want
+    # to always do it as long as the latest *supported* WAPI version supports them. But we
+    # don't want to query for the latest supported version every time. So we'll do it once
+    # and save the value.
+    if (!$script:HighestWAPISupported) {
+        $versions = (Invoke-IBWAPI -Uri "$APIBase/?_schema" @cfg).supported_versions
+        $versions = $versions | Sort-Object @{E={[Version]$_}}
+        $script:HighestWAPISupported = $versions | Select-Object -Last 1
+    }
+
+    $uri = "$APIBase$($ObjectType)?_schema=1"
+
+    if ([Version]$script:HighestWAPISupported -ge [Version]'2.6') {
+        $uri += "&_schema_version=2&_schema_searchable=1&_get_doc=1"
+    }
+
+    $schema = Invoke-IBWAPI -Uri $uri @cfg
+
+    # return the schema object directly, if asked
+    if ($Raw) {
+        return $schema
+    }
+
+    # prep some stuff we'll need for pretty printing
+    $prettyColors = @{ForegroundColor='Cyan';BackgroundColor='Black'}
+    $consoleWidth = $host.ui.RawUI.maxWindowSize.Width - 1
+
+    function BlankLine() { ' ' | Word-Wrap -Pad | Write-Host @prettyColors }
+    function PrettifySupports([string]$supports) {
+        # The 'supports' property of a schema Field is a lower cases string
+        # containing one or more of r,w,u,c,d for the supported operations of
+        # that field. Most, but not all, are in a standard order. There are
+        # instances of things like 'wu' vs 'uw'. We want to standardize the
+        # order (RWUSD), uppercase the letters, and insert spaces for the operations
+        # not included in the list.
+        $ret = ''
+        'R','W','U','S','D' | %{
+            if ($supports -like "*$_*") {
+                $ret += $_
+            } else {
+                $ret += ' '
+            }
+        }
+        $ret
+        # Basic string concatentation obviously isn't the most efficient thing to
+        # do here. But we can optimize later if it becomes a problem.
+    }
+
+    if (!$schema.type) {
+        # base schema object
+        BlankLine
+        "Requested Version: $($schema.requested_version)" | Word-Wrap -Pad | Write-Host @prettyColors
+        BlankLine
+        "Supported Versions:" | Word-Wrap -Pad | Write-Host @prettyColors
+        BlankLine
+        $schema | Select-Object -expand supported_versions | Format-Columns -prop {$_} -col 4 @prettyColors
+        BlankLine
+        "Supported Objects:" | Word-Wrap -Pad | Write-Host @prettyColors
+        BlankLine
+        $schema | Select-Object -expand supported_objects | Format-Columns -prop {$_} @prettyColors
+        BlankLine
+    }
+    else {
+        # With _schema_version=2, we functions are potentially returned in the normal
+        # list of fields. But we want to split those out and display them differently.
+        $funcs = $schema.fields | ?{ $_.wapi_primitive -eq 'funccall' }
+        $schema.fields = $schema.fields | ?{ $_.wapi_primitive -ne 'funccall' }
+
+        # object type schema
+        $typeStr = "$($schema.type) (WAPI $($schema.version))"
+        BlankLine
+        'OBJECT' | Word-Wrap -Pad | Write-Host @prettyColors
+        $typeStr | Word-Wrap -Pad -Indent 4 | Write-Host @prettyColors
+        if ($schema.restrictions) {
+            BlankLine
+            'RESTRICTIONS' | Word-Wrap -Pad | Write-Host @prettyColors
+            "$($schema.restrictions -join ', ')" | Word-Wrap -Pad -Indent 4 | Write-Host @prettyColors
+        }
+        if ($schema.cloud_additional_restrictions) {
+            BlankLine
+            'CLOUD RESTRICTIONS' | Word-Wrap -Pad | Write-Host @prettyColors
+            "$($schema.cloud_additional_restrictions -join ', ')" | Word-Wrap -Pad -Indent 4 | Write-Host @prettyColors
+        }
+
+        if ($schema.fields.count -gt 0) {
+            # get the length of the longest field name so we can make sure not to truncate that column
+            $nameMax = [Math]::Max(($schema.fields.name | sort -desc @{E={$_.length}} | select -first 1).length + 1, 6)
+            # get the length of the longest type name (including potential array brackets) so we can
+            # make sure not to truncate that column
+            $typeMax = [Math]::Max(($schema.fields.type | sort -desc @{E={$_.length}} | select -first 1).length + 3, 5)
+
+            $format = "{0,-$nameMax}{1,-$typeMax}{2,-9}{3,-5}{4,-6}"
+            BlankLine
+            ($format -f 'Field','Type','Supports','Base','Search') | Word-Wrap -Pad | Write-Host @prettyColors
+            ($format -f '-----','----','--------','----','------') | Word-Wrap -Pad | Write-Host @prettyColors
+
+            # sort base fields first, then alphabetical with the rest
+            $schema.fields | sort @{E='standard_field';Desc=$true},@{E='name';Desc=$false} | %{
+
+                # skip fields not specified in $Fields unless it's empty
+                if ($Fields.count -gt 0) {
+                    $name = $_.name
+                    if (($Fields | %{ $name -like $_ }) -notcontains $true) {
+                        return
+                    }
+                }
+
+                # skip fields that don't include at least one specified Operation unless no operations were specified
+                if ($Operations.count -gt 0) {
+                    $supports = $_.supports
+                    if (($Operations | %{ $supports -like "*$_*"}) -notcontains $true) {
+                        return
+                    }
+                }
+
+                # set the Base column value
+                $base = ''
+                if ($_.standard_field) { $base = 'X' }
+
+                # put brackets around array types
+                if ($_.is_array) {
+                    for ($i=0; $i -lt $_.type.count; $i++) {
+                        $_.type[$i] = "[$($_.type[$i])]"
+                    }
+                }
+
+                # there should always be at least one type, so write that with the rest of
+                # the table values
+                ($format -f $_.name,$_.type[0],(PrettifySupports $_.supports),$base,$_.searchable_by) | Word-Wrap -Pad | Write-Host @prettyColors
+
+                # write additional types on their own line
+                if ($_.type.count -gt 1) {
+                    for ($i=1; $i -lt $_.type.count; $i++) {
+                        "$(''.PadRight($nameMax))$($_.type[$i])" | Word-Wrap -Pad | Write-Host @prettyColors
+                    }
+                }
+            }
+        }
+
+        if ($funcs.count -gt 0) {
+            BlankLine
+            "FUNCTIONS" | Word-Wrap -Pad | Write-Host @prettyColors
+        }
+        $funcs | %{
+
+            if ($Functions.count -le 0) {
+                $funcStr = "$($_.name)($($_.schema.input_fields.name -join ', '))"
+                if ($_.schema.output_fields.count -gt 0) {
+                    $funcStr += " => $($_.schema.output_fields.name -join ', ')"
+                }
+                $funcStr | Word-Wrap -Indent 4 -Pad | Write-Host @prettyColors
+            }
+            else {
+                $name = $_.name
+
+                # skip functions that weren't specified in the list
+                if (($Functions | %{ $name -like "*$_*" }) -notcontains $true) {
+                    return
+                }
+
+                BlankLine
+                '    ----------------------------------------------------------' | Word-Wrap -Pad | Write-Host @prettyColors
+                $_.name | Word-Wrap -Indent 4 -Pad | Write-Host @prettyColors
+                '    ----------------------------------------------------------' | Word-Wrap -Pad | Write-Host @prettyColors
+                if ($_.doc) {
+                    $_.doc | Word-Wrap -Indent 8 -Pad | Write-Host @prettyColors
+                }
+                if ($_.schema.input_fields.count -gt 0) {
+                    BlankLine
+                    "Input fields" | Word-Wrap -Indent 4 -Pad | Write-Host @prettyColors
+                    foreach ($field in $_.schema.input_fields) {
+                        if ($field.enum_values) {
+                            $type = $field.enum_values -join '|'
+                        } else {
+                            $type = $field.type -join '|'
+                        }
+                        if ($field.is_array) { $type = "[$type]" }
+                        BlankLine
+                        "$($field.name) - $type" | Word-Wrap -Indent 8 -Pad | Write-Host @prettyColors
+                        $field.doc | Word-Wrap -Indent 12 -Pad | Write-Host @prettyColors
+                    }
+                }
+                if ($_.schema.output_fields.count -gt 0) {
+                    BlankLine
+                    "Output fields" | Word-Wrap -Indent 4 -Pad | Write-Host @prettyColors
+                    foreach ($field in $_.schema.input_fields) {
+                        if ($field.enum_values) {
+                            $type = $field.enum_values -join '|'
+                        } else {
+                            $type = $field.type -join '|'
+                        }
+                        if ($field.is_array) { $type = "[$type]" }
+                        BlankLine
+                        "$($field.name) - $type" | Word-Wrap -Indent 8 -Pad | Write-Host @prettyColors
+                        $field.doc | Word-Wrap -Indent 12 -Pad | Write-Host @prettyColors
+                    }
+                }
+            }
+
+        } # end $funcs loop
+
+
+
+    }
+
+
+
+
+    <#
+    .SYNOPSIS
+        Query the schema of an object or the base appliance.
+
+    .DESCRIPTION
+        Without any parameters, this function will return the base appliance schema object which among other things include the list of supported WAPI versions and object types. Providing an -ObjectType will return the schema object for that type which among other things includes the list of supported fields and how they may be queried.
+
+    .PARAMETER ObjectType
+        Object type string. (e.g. network, record:host, range)
+
+    .PARAMETER Raw
+        If set, the schema object will be returned as-is rather than pretty printing the output. All parameters except -ObjectType will be ignored.
+
+    .PARAMETER Fields
+        A list of Field names to include in the output. Wildcards are supported. If not specified, all Fields will be included.
+
+    .PARAMETER Operations
+        A list of supported operation codes: r (read), w (write/create), u (update/set), s (search), d (delete). Only the Fields supporting at least one of these operations will be included in the output. If not specified, all Fields will be included.
+
+    .PARAMETER WAPIHost
+        The fully qualified DNS name or IP address of the Infoblox WAPI endpoint (usually the grid master). This parameter is required if not already set using Set-IBWAPIConfig.
+
+    .PARAMETER WAPIVersion
+        The version of the Infoblox WAPI to make calls against (e.g. '2.2'). This parameter is required if not already set using Set-IBWAPIConfig.
+
+    .PARAMETER Credential
+        Username and password for the Infoblox appliance. This parameter is required unless -WebSession is specified or was already set using Set-IBWAPIConfig.
+
+    .PARAMETER WebSession
+        A WebRequestSession object returned by Get-IBSession or set when using Invoke-IBWAPI with the -SessionVariable parameter. This parameter is required unless -Credential is specified or was already set using Set-IBWAPIConfig.
+
+    .PARAMETER IgnoreCertificateValidation
+        If set, SSL/TLS certificate validation will be disabled. Overrides value stored with Set-IBWAPIConfig.
+
+    .OUTPUTS
+        Zero or more objects found by the search or object reference. If an object reference is specified that doesn't exist, an error will be thrown.
+
+    .EXAMPLE
+        Get-IBSchema
+
+        Get the root schema object
+
+    .EXAMPLE
+        Get-IBSchema record:host
+
+        Get the schema object for the record:host type.
+
+    .LINK
+        Project: https://github.com/rmbolger/Posh-IBWAPI
+
+    .LINK
+        Get-IBObject
+
+    #>
+}

--- a/Posh-IBWAPI/Public/Get-IBSchema.ps1
+++ b/Posh-IBWAPI/Public/Get-IBSchema.ps1
@@ -263,6 +263,9 @@ function Get-IBSchema {
                     if ($_.standard_field) {
                         "This field is part of the base object." | Word-Wrap -Indent 8 -Pad | Write-Host
                     }
+                    if ($_.supports_inline_funccall) {
+                        "This field supports inline function calls. See full docs for more detail."
+                    }
                     if ($_.searchable_by) {
                         BlankLine
                         "This field is available for search via:" | Word-Wrap -Indent 8 -Pad | Write-Host
@@ -274,12 +277,21 @@ function Get-IBSchema {
                         if ($_.searchable_by -like '*>*') { "'>=' (greater than or equal to)" | Word-Wrap -Indent 12 -Pad | Write-Host }
                     }
 
-                    # supports_inline_funccall
-                    # schema? (sub object defs)
-                    # wapi_primitive = struct?
+                    # At this point, the only other thing to potentially deal with is if this field is
+                    # a struct. If so, there will be a sub-schema object with it's own set of fields. But
+                    # each of those fields might also be a struct with even more sub-schemas, potentially going
+                    # 3+ levels deep. Even the HTML docs don't try to cram all that into a field's description.
+                    # They stick with links to the struct details.
+
+                    # Unfortunately, the schema queries don't support querying structs directly. So in order to
+                    # fake making something like that work, we would need to basically cache struct definitions
+                    # (per WAPI version) as they're queried. Maybe have some way to pre-cache all the structs for
+                    # a particular version by whipping through the supported object types?
+
+                    # In any case, it's a non-trivial task for another day. And I don't want it to delay the schema
+                    # querying release.
 
                     BlankLine
-
                 }
 
             } else {

--- a/Posh-IBWAPI/Public/Get-IBSchema.ps1
+++ b/Posh-IBWAPI/Public/Get-IBSchema.ps1
@@ -77,8 +77,8 @@ function Get-IBSchema {
             # multiple matches
             $message = "Multiple object matches found for $($ObjectType)"
             if ($Raw) { throw $message }
-            "$($message):" | Word-Wrap -Pad | Write-Host
-            $objMatches | %{ $_ | Word-Wrap -Pad | Write-Host }
+            Write-Output "$($message):"
+            $objMatches | %{ Write-Output $_ }
             return
         }
         elseif ($objMatches.count -eq 0 ) {
@@ -89,15 +89,15 @@ function Get-IBSchema {
                 # multiple matches
                 $message = "Multiple object matches found for $($ObjectType)"
                 if ($Raw) { throw $message }
-                "$($message):" | Word-Wrap -Pad | Write-Host
-                $objMatches | %{ $_ | Word-Wrap -Pad | Write-Host }
+                Write-Output "$($message):"
+                $objMatches | %{ Write-Output $_ }
                 return
             }
             elseif ($objMatches.count -eq 0) {
                 # no matches, even with wildcards
                 $message = "No matches found for $($ObjectType)"
                 if ($Raw) { throw $message }
-                else { $message | Word-Wrap -Pad | Write-Warning }
+                else { Write-Warning $message }
                 return
             } else {
                 $ObjectType = $objMatches
@@ -139,7 +139,7 @@ function Get-IBSchema {
         return
     }
 
-    function BlankLine() { ' ' | Word-Wrap -Pad | Write-Host }
+    function BlankLine() { Write-Output '' }
     function PrettifySupports([string]$supports) {
         # The 'supports' property of a schema Field is a lower cases string
         # containing one or more of r,w,u,d,s for the supported operations of
@@ -195,32 +195,32 @@ function Get-IBSchema {
     if (!$schema.type) {
         # base schema object
         BlankLine
-        "Requested Version: $($schema.requested_version)" | Word-Wrap -Pad | Write-Host
+        Write-Output "Requested Version: $($schema.requested_version)"
         BlankLine
-        "Supported Versions:" | Word-Wrap -Pad | Write-Host
+        Write-Output "Supported Versions:"
         BlankLine
-        $schema | Select-Object -expand supported_versions | Format-Columns -prop {$_} -col 4
+        Write-Output ($schema | Select-Object -expand supported_versions | Format-Columns -prop {$_} -col 4)
         BlankLine
-        "Supported Objects:" | Word-Wrap -Pad | Write-Host
+        Write-Output "Supported Objects:"
         BlankLine
-        $schema | Select-Object -expand supported_objects | Format-Columns -prop {$_}
+        Write-Output ($schema | Select-Object -expand supported_objects | Format-Columns -prop {$_})
         BlankLine
     }
     else {
         # display the top level object info
         $typeStr = "$($schema.type) (WAPI $($schema.version))"
         BlankLine
-        'OBJECT' | Word-Wrap -Pad | Write-Host
-        $typeStr | Word-Wrap -Pad -Indent 4 | Write-Host
+        Write-Output 'OBJECT'
+        Write-Output ($typeStr | Word-Wrap -Indent 4)
         if ($schema.restrictions) {
             BlankLine
-            'RESTRICTIONS' | Word-Wrap -Pad | Write-Host
-            "$($schema.restrictions -join ', ')" | Word-Wrap -Pad -Indent 4 | Write-Host
+            Write-Output 'RESTRICTIONS'
+            Write-Output ("$($schema.restrictions -join ', ')" | Word-Wrap -Indent 4)
         }
         if ($schema.cloud_additional_restrictions) {
             BlankLine
-            'CLOUD RESTRICTIONS' | Word-Wrap -Pad | Write-Host
-            "$($schema.cloud_additional_restrictions -join ', ')" | Word-Wrap -Pad -Indent 4 | Write-Host
+            Write-Output 'CLOUD RESTRICTIONS'
+            Write-Output ("$($schema.cloud_additional_restrictions -join ', ')" | Word-Wrap -Indent 4)
         }
 
         # With _schema_version=2, functions are returned in the normal
@@ -256,38 +256,38 @@ function Get-IBSchema {
                 # Display the detailed view
 
                 BlankLine
-                'FIELDS' | Word-Wrap -Pad | Write-Host
+                Write-Output 'FIELDS'
 
                 # loop through fields alphabetically
                 $fieldList | sort name | %{
 
-                    "$($_.name) <$(PrettifyType $_)>" | Word-Wrap -Indent 4 -Pad | Write-Host
+                    Write-Output ("$($_.name) <$(PrettifyType $_)>" | Word-Wrap -Indent 4)
 
                     if ($_.doc) {
-                        $_.doc | Word-Wrap -Indent 8 -Pad | Write-Host
+                        Write-Output ($_.doc | Word-Wrap -Indent 8)
                     }
                     BlankLine
 
-                    "Supports: $(PrettifySupportsDetail $_.supports)" | Word-Wrap -Indent 8 -Pad | Write-Host
+                    Write-Output ("Supports: $(PrettifySupportsDetail $_.supports)" | Word-Wrap -Indent 8)
 
                     if ($_.overridden_by) {
-                        "Overridden By: $($_.overridden_by)" | Word-Wrap -Indent 8 -Pad | Write-Host
+                        Write-Output ("Overridden By: $($_.overridden_by)" | Word-Wrap -Indent 8)
                     }
                     if ($_.standard_field) {
-                        "This field is part of the base object." | Word-Wrap -Indent 8 -Pad | Write-Host
+                        Write-Output ("This field is part of the base object." | Word-Wrap -Indent 8)
                     }
                     if ($_.supports_inline_funccall) {
-                        "This field supports inline function calls. See full docs for more detail."
+                        Write-Output ("This field supports inline function calls. See full docs for more detail." | Word-Wrap -Indent 8)
                     }
                     if ($_.searchable_by) {
                         BlankLine
-                        "This field is available for search via:" | Word-Wrap -Indent 8 -Pad | Write-Host
-                        if ($_.searchable_by -like '*=*') { "'=' (exact equality)" | Word-Wrap -Indent 12 -Pad | Write-Host }
-                        if ($_.searchable_by -like '*!*') { "'!=' (negative equality)" | Word-Wrap -Indent 12 -Pad | Write-Host }
-                        if ($_.searchable_by -like '*:*') { "':=' (case insensitive search)" | Word-Wrap -Indent 12 -Pad | Write-Host }
-                        if ($_.searchable_by -like '*~*') { "'~=' (regular expression)" | Word-Wrap -Indent 12 -Pad | Write-Host }
-                        if ($_.searchable_by -like '*<*') { "'<=' (less than or equal to)" | Word-Wrap -Indent 12 -Pad | Write-Host }
-                        if ($_.searchable_by -like '*>*') { "'>=' (greater than or equal to)" | Word-Wrap -Indent 12 -Pad | Write-Host }
+                        Write-Output ("This field is available for search via:" | Word-Wrap -Indent 8)
+                        if ($_.searchable_by -like '*=*') { Write-Output ("'=' (exact equality)" | Word-Wrap -Indent 12) }
+                        if ($_.searchable_by -like '*!*') { Write-Output ("'!=' (negative equality)" | Word-Wrap -Indent 12) }
+                        if ($_.searchable_by -like '*:*') { Write-Output ("':=' (case insensitive search)" | Word-Wrap -Indent 12) }
+                        if ($_.searchable_by -like '*~*') { Write-Output ("'~=' (regular expression)" | Word-Wrap -Indent 12) }
+                        if ($_.searchable_by -like '*<*') { Write-Output ("'<=' (less than or equal to)" | Word-Wrap -Indent 12) }
+                        if ($_.searchable_by -like '*>*') { Write-Output ("'>=' (greater than or equal to)" | Word-Wrap -Indent 12) }
                     }
 
                     # At this point, the only other thing to potentially deal with is if this field is
@@ -318,8 +318,8 @@ function Get-IBSchema {
 
                 $format = "{0,-$nameMax}{1,-$typeMax}{2,-9}{3,-5}{4,-6}"
                 BlankLine
-                ($format -f 'FIELD','TYPE','SUPPORTS','BASE','SEARCH') | Word-Wrap -Pad | Write-Host
-                ($format -f '-----','----','--------','----','------') | Word-Wrap -Pad | Write-Host
+                Write-Output ($format -f 'FIELD','TYPE','SUPPORTS','BASE','SEARCH')
+                Write-Output ($format -f '-----','----','--------','----','------')
 
                 # loop through fields alphabetically
                 $fieldList | sort @{E='name';Desc=$false} | %{
@@ -337,12 +337,12 @@ function Get-IBSchema {
 
                     # there should always be at least one type, so write that with the rest of
                     # the table values
-                    ($format -f $_.name,$_.type[0],(PrettifySupports $_.supports),$base,$_.searchable_by) | Word-Wrap -Pad | Write-Host
+                    Write-Output ($format -f $_.name,$_.type[0],(PrettifySupports $_.supports),$base,$_.searchable_by)
 
                     # write additional types on their own line
                     if ($_.type.count -gt 1) {
                         for ($i=1; $i -lt $_.type.count; $i++) {
-                            "$(''.PadRight($nameMax))$($_.type[$i])" | Word-Wrap -Pad | Write-Host
+                            Write-Output "$(''.PadRight($nameMax))$($_.type[$i])"
                         }
                     }
                 }
@@ -352,34 +352,34 @@ function Get-IBSchema {
         if ($funcList.count -gt 0 -and !$NoFunctions) {
 
             BlankLine
-            "FUNCTIONS" | Word-Wrap -Pad | Write-Host
+            Write-Output "FUNCTIONS"
 
             if ($Detailed) {
 
                 $funcList | %{
                     BlankLine
-                    '    ----------------------------------------------------------' | Word-Wrap -Pad | Write-Host
-                    $_.name | Word-Wrap -Indent 4 -Pad | Write-Host
-                    '    ----------------------------------------------------------' | Word-Wrap -Pad | Write-Host
+                    Write-Output '    ----------------------------------------------------------'
+                    Write-Output ($_.name | Word-Wrap -Indent 4)
+                    Write-Output '    ----------------------------------------------------------'
                     if ($_.doc) {
-                        $_.doc | Word-Wrap -Indent 8 -Pad | Write-Host
+                        Write-Output ($_.doc | Word-Wrap -Indent 8)
                     }
                     if ($_.schema.input_fields.count -gt 0) {
                         BlankLine
-                        "INPUTS" | Word-Wrap -Indent 4 -Pad | Write-Host
+                        Write-Output ("INPUTS" | Word-Wrap -Indent 4)
                         foreach ($field in $_.schema.input_fields) {
                             BlankLine
-                            "$($field.name) <$(PrettifyType $field)>" | Word-Wrap -Indent 8 -Pad | Write-Host
-                            $field.doc | Word-Wrap -Indent 12 -Pad | Write-Host
+                            Write-Output ("$($field.name) <$(PrettifyType $field)>" | Word-Wrap -Indent 8)
+                            Write-Output ($field.doc | Word-Wrap -Indent 12)
                         }
                     }
                     if ($_.schema.output_fields.count -gt 0) {
                         BlankLine
-                        "OUTPUTS" | Word-Wrap -Indent 4 -Pad | Write-Host
+                        Write-Output ("OUTPUTS" | Word-Wrap -Indent 4)
                         foreach ($field in $_.schema.output_fields) {
                             BlankLine
-                            "$($field.name) <$(PrettifyType $field)>" | Word-Wrap -Indent 8 -Pad | Write-Host
-                            $field.doc | Word-Wrap -Indent 12 -Pad | Write-Host
+                            Write-Output ("$($field.name) <$(PrettifyType $field)>" | Word-Wrap -Indent 8)
+                            Write-Output ($field.doc | Word-Wrap -Indent 12)
                         }
                     }
 
@@ -392,7 +392,7 @@ function Get-IBSchema {
                     if ($_.schema.output_fields.count -gt 0) {
                         $funcListtr += " => $($_.schema.output_fields.name -join ', ')"
                     }
-                    $funcListtr | Word-Wrap -Indent 4 -Pad | Write-Host
+                    Write-Output ($funcListtr | Word-Wrap -Indent 4)
                 }
 
             } # end simple function view

--- a/Posh-IBWAPI/Public/Get-IBSchema.ps1
+++ b/Posh-IBWAPI/Public/Get-IBSchema.ps1
@@ -41,10 +41,9 @@ function Get-IBSchema {
         }
         $cfg.HighestVersion = (HighestVer $WAPIHost $opts.WebSession -IgnoreCertificateValidation:$opts.IgnoreCertificateValidation)
         Write-Verbose "Set highest version: $($cfg.HighestVersion)"
-
-        if ([Version]$cfg.HighestVersion -lt [Version]'1.7.5') {
-            throw "NIOS WAPI $($cfg.HighestVersion) doesn't support schema queries"
-        }
+    }
+    if ([Version]$cfg.HighestVersion -lt [Version]'1.7.5') {
+        throw "NIOS WAPI $($cfg.HighestVersion) doesn't support schema queries"
     }
 
     # cache some base schema stuff that we'll potentially need later

--- a/Posh-IBWAPI/Public/Get-IBSchema.ps1
+++ b/Posh-IBWAPI/Public/Get-IBSchema.ps1
@@ -6,7 +6,9 @@ function Get-IBSchema {
         [switch]$Raw,
         [string[]]$Fields,
         [string[]]$Operations,
+        [switch]$NoFields,
         [string[]]$Functions,
+        [switch]$NoFunctions,
         [Alias('host')]
         [string]$WAPIHost,
         [Alias('version')]
@@ -46,7 +48,7 @@ function Get-IBSchema {
 
     # cache some base schema stuff that we'll potentially need later
     if (!$cfg.SupportedVersions -or !$cfg[$WAPIVersion]) {
-        $schema = Invoke-IBWAPI -Uri "$APIBase/?_schema" @opts
+        $schema = Invoke-IBWAPI -Uri "$($APIBase)?_schema" @opts
 
         # set supported versions
         $cfg.SupportedVersions = $schema.supported_versions | Sort-Object @{E={[Version]$_}}
@@ -65,10 +67,6 @@ function Get-IBSchema {
         return
     }
 
-    # prep some stuff we'll need for pretty printing
-    $prettyColors = @{ForegroundColor='Cyan';BackgroundColor='Black'}
-    $consoleWidth = $host.ui.RawUI.maxWindowSize.Width - 1
-
     if (![String]::IsNullOrWhiteSpace($ObjectType)) {
         # We want to support wildcard searches and partial matching on object types.
         Write-Verbose "ObjectType: $ObjectType"
@@ -78,27 +76,30 @@ function Get-IBSchema {
             # multiple matches
             $message = "Multiple object matches found for $($ObjectType)"
             if ($Raw) { throw $message }
-            "$($message):" | Word-Wrap -Pad | Write-Host @prettyColors
-            $objMatches | %{ $_ | Word-Wrap -Pad | Write-Host @prettyColors }
+            "$($message):" | Word-Wrap -Pad | Write-Host
+            $objMatches | %{ $_ | Word-Wrap -Pad | Write-Host }
             return
         }
         elseif ($objMatches.count -eq 0 ) {
+            Write-Verbose "Retrying matches with implied wildcards"
             # retry matching with implied wildcards
             $objMatches = $cfg[$WAPIVersion] | %{ if ($_ -like "*$ObjectType*") { $_ } }
             if ($objMatches.count -gt 1) {
                 # multiple matches
                 $message = "Multiple object matches found for $($ObjectType)"
                 if ($Raw) { throw $message }
-                "$($message):" | Word-Wrap -Pad | Write-Host @prettyColors
-                $objMatches | %{ $_ | Word-Wrap -Pad | Write-Host @prettyColors }
+                "$($message):" | Word-Wrap -Pad | Write-Host
+                $objMatches | %{ $_ | Word-Wrap -Pad | Write-Host }
                 return
             }
             elseif ($objMatches.count -eq 0) {
                 # no matches, even with wildcards
                 $message = "No matches found for $($ObjectType)"
                 if ($Raw) { throw $message }
-                else { $message | Word-Wrap -Pad | Write-Debug @prettyColors }
+                else { $message | Word-Wrap -Pad | Write-Warning }
                 return
+            } else {
+                $ObjectType = $objMatches
             }
         }
         else {
@@ -125,7 +126,7 @@ function Get-IBSchema {
     # return the schema object directly, if asked
     if ($Raw) { return $schema }
 
-    function BlankLine() { ' ' | Word-Wrap -Pad | Write-Host @prettyColors }
+    function BlankLine() { ' ' | Word-Wrap -Pad | Write-Host }
     function PrettifySupports([string]$supports) {
         # The 'supports' property of a schema Field is a lower cases string
         # containing one or more of r,w,u,c,d for the supported operations of
@@ -149,15 +150,15 @@ function Get-IBSchema {
     if (!$schema.type) {
         # base schema object
         BlankLine
-        "Requested Version: $($schema.requested_version)" | Word-Wrap -Pad | Write-Host @prettyColors
+        "Requested Version: $($schema.requested_version)" | Word-Wrap -Pad | Write-Host
         BlankLine
-        "Supported Versions:" | Word-Wrap -Pad | Write-Host @prettyColors
+        "Supported Versions:" | Word-Wrap -Pad | Write-Host
         BlankLine
-        $schema | Select-Object -expand supported_versions | Format-Columns -prop {$_} -col 4 @prettyColors
+        $schema | Select-Object -expand supported_versions | Format-Columns -prop {$_} -col 4
         BlankLine
-        "Supported Objects:" | Word-Wrap -Pad | Write-Host @prettyColors
+        "Supported Objects:" | Word-Wrap -Pad | Write-Host
         BlankLine
-        $schema | Select-Object -expand supported_objects | Format-Columns -prop {$_} @prettyColors
+        $schema | Select-Object -expand supported_objects | Format-Columns -prop {$_}
         BlankLine
     }
     else {
@@ -169,20 +170,20 @@ function Get-IBSchema {
         # object type schema
         $typeStr = "$($schema.type) (WAPI $($schema.version))"
         BlankLine
-        'OBJECT' | Word-Wrap -Pad | Write-Host @prettyColors
-        $typeStr | Word-Wrap -Pad -Indent 4 | Write-Host @prettyColors
+        'OBJECT' | Word-Wrap -Pad | Write-Host
+        $typeStr | Word-Wrap -Pad -Indent 4 | Write-Host
         if ($schema.restrictions) {
             BlankLine
-            'RESTRICTIONS' | Word-Wrap -Pad | Write-Host @prettyColors
-            "$($schema.restrictions -join ', ')" | Word-Wrap -Pad -Indent 4 | Write-Host @prettyColors
+            'RESTRICTIONS' | Word-Wrap -Pad | Write-Host
+            "$($schema.restrictions -join ', ')" | Word-Wrap -Pad -Indent 4 | Write-Host
         }
         if ($schema.cloud_additional_restrictions) {
             BlankLine
-            'CLOUD RESTRICTIONS' | Word-Wrap -Pad | Write-Host @prettyColors
-            "$($schema.cloud_additional_restrictions -join ', ')" | Word-Wrap -Pad -Indent 4 | Write-Host @prettyColors
+            'CLOUD RESTRICTIONS' | Word-Wrap -Pad | Write-Host
+            "$($schema.cloud_additional_restrictions -join ', ')" | Word-Wrap -Pad -Indent 4 | Write-Host
         }
 
-        if ($schema.fields.count -gt 0) {
+        if ($schema.fields.count -gt 0 -and !$NoFields) {
             # get the length of the longest field name so we can make sure not to truncate that column
             $nameMax = [Math]::Max(($schema.fields.name | sort -desc @{E={$_.length}} | select -first 1).length + 1, 6)
             # get the length of the longest type name (including potential array brackets) so we can
@@ -191,8 +192,8 @@ function Get-IBSchema {
 
             $format = "{0,-$nameMax}{1,-$typeMax}{2,-9}{3,-5}{4,-6}"
             BlankLine
-            ($format -f 'Field','Type','Supports','Base','Search') | Word-Wrap -Pad | Write-Host @prettyColors
-            ($format -f '-----','----','--------','----','------') | Word-Wrap -Pad | Write-Host @prettyColors
+            ($format -f 'Field','Type','Supports','Base','Search') | Word-Wrap -Pad | Write-Host
+            ($format -f '-----','----','--------','----','------') | Word-Wrap -Pad | Write-Host
 
             # sort base fields first, then alphabetical with the rest
             $schema.fields | sort @{E='standard_field';Desc=$true},@{E='name';Desc=$false} | %{
@@ -226,81 +227,82 @@ function Get-IBSchema {
 
                 # there should always be at least one type, so write that with the rest of
                 # the table values
-                ($format -f $_.name,$_.type[0],(PrettifySupports $_.supports),$base,$_.searchable_by) | Word-Wrap -Pad | Write-Host @prettyColors
+                ($format -f $_.name,$_.type[0],(PrettifySupports $_.supports),$base,$_.searchable_by) | Word-Wrap -Pad | Write-Host
 
                 # write additional types on their own line
                 if ($_.type.count -gt 1) {
                     for ($i=1; $i -lt $_.type.count; $i++) {
-                        "$(''.PadRight($nameMax))$($_.type[$i])" | Word-Wrap -Pad | Write-Host @prettyColors
+                        "$(''.PadRight($nameMax))$($_.type[$i])" | Word-Wrap -Pad | Write-Host
                     }
                 }
             }
         }
 
-        if ($funcs.count -gt 0) {
-            BlankLine
-            "FUNCTIONS" | Word-Wrap -Pad | Write-Host @prettyColors
-        }
-        $funcs | %{
-
-            if ($Functions.count -le 0) {
-                $funcStr = "$($_.name)($($_.schema.input_fields.name -join ', '))"
-                if ($_.schema.output_fields.count -gt 0) {
-                    $funcStr += " => $($_.schema.output_fields.name -join ', ')"
-                }
-                $funcStr | Word-Wrap -Indent 4 -Pad | Write-Host @prettyColors
-            }
-            else {
-                $name = $_.name
-
-                # skip functions that weren't specified in the list
-                if (($Functions | %{ $name -like "*$_*" }) -notcontains $true) {
-                    return
-                }
-
+        if (!$NoFunctions) {
+            if ($funcs.count -gt 0) {
                 BlankLine
-                '    ----------------------------------------------------------' | Word-Wrap -Pad | Write-Host @prettyColors
-                $_.name | Word-Wrap -Indent 4 -Pad | Write-Host @prettyColors
-                '    ----------------------------------------------------------' | Word-Wrap -Pad | Write-Host @prettyColors
-                if ($_.doc) {
-                    $_.doc | Word-Wrap -Indent 8 -Pad | Write-Host @prettyColors
-                }
-                if ($_.schema.input_fields.count -gt 0) {
-                    BlankLine
-                    "Input fields" | Word-Wrap -Indent 4 -Pad | Write-Host @prettyColors
-                    foreach ($field in $_.schema.input_fields) {
-                        if ($field.enum_values) {
-                            $type = $field.enum_values -join '|'
-                        } else {
-                            $type = $field.type -join '|'
-                        }
-                        if ($field.is_array) { $type = "[$type]" }
-                        BlankLine
-                        "$($field.name) - $type" | Word-Wrap -Indent 8 -Pad | Write-Host @prettyColors
-                        $field.doc | Word-Wrap -Indent 12 -Pad | Write-Host @prettyColors
-                    }
-                }
-                if ($_.schema.output_fields.count -gt 0) {
-                    BlankLine
-                    "Output fields" | Word-Wrap -Indent 4 -Pad | Write-Host @prettyColors
-                    foreach ($field in $_.schema.input_fields) {
-                        if ($field.enum_values) {
-                            $type = $field.enum_values -join '|'
-                        } else {
-                            $type = $field.type -join '|'
-                        }
-                        if ($field.is_array) { $type = "[$type]" }
-                        BlankLine
-                        "$($field.name) - $type" | Word-Wrap -Indent 8 -Pad | Write-Host @prettyColors
-                        $field.doc | Word-Wrap -Indent 12 -Pad | Write-Host @prettyColors
-                    }
-                }
+                "FUNCTIONS" | Word-Wrap -Pad | Write-Host
             }
+            $funcs | %{
 
-        } # end $funcs loop
+                if ($Functions.count -le 0) {
+                    $funcStr = "$($_.name)($($_.schema.input_fields.name -join ', '))"
+                    if ($_.schema.output_fields.count -gt 0) {
+                        $funcStr += " => $($_.schema.output_fields.name -join ', ')"
+                    }
+                    $funcStr | Word-Wrap -Indent 4 -Pad | Write-Host
+                }
+                else {
+                    $name = $_.name
 
+                    # skip functions that weren't specified in the list
+                    if (($Functions | %{ $name -like "*$_*" }) -notcontains $true) {
+                        return
+                    }
 
+                    BlankLine
+                    '    ----------------------------------------------------------' | Word-Wrap -Pad | Write-Host
+                    $_.name | Word-Wrap -Indent 4 -Pad | Write-Host
+                    '    ----------------------------------------------------------' | Word-Wrap -Pad | Write-Host
+                    if ($_.doc) {
+                        $_.doc | Word-Wrap -Indent 8 -Pad | Write-Host
+                    }
+                    if ($_.schema.input_fields.count -gt 0) {
+                        BlankLine
+                        "Input fields" | Word-Wrap -Indent 4 -Pad | Write-Host
+                        foreach ($field in $_.schema.input_fields) {
+                            if ($field.enum_values) {
+                                $type = $field.enum_values -join '|'
+                            } else {
+                                $type = $field.type -join '|'
+                            }
+                            if ($field.is_array) { $type = "[$type]" }
+                            BlankLine
+                            "$($field.name) - $type" | Word-Wrap -Indent 8 -Pad | Write-Host
+                            $field.doc | Word-Wrap -Indent 12 -Pad | Write-Host
+                        }
+                    }
+                    if ($_.schema.output_fields.count -gt 0) {
+                        BlankLine
+                        "Output fields" | Word-Wrap -Indent 4 -Pad | Write-Host
+                        foreach ($field in $_.schema.output_fields) {
+                            if ($field.enum_values) {
+                                $type = $field.enum_values -join '|'
+                            } else {
+                                $type = $field.type -join '|'
+                            }
+                            if ($field.is_array) { $type = "[$type]" }
+                            BlankLine
+                            "$($field.name) - $type" | Word-Wrap -Indent 8 -Pad | Write-Host
+                            $field.doc | Word-Wrap -Indent 12 -Pad | Write-Host
+                        }
+                    }
+                }
 
+            } # end $funcs loop
+        }
+
+        BlankLine
     }
 
 
@@ -311,19 +313,28 @@ function Get-IBSchema {
         Query the schema of an object or the base appliance.
 
     .DESCRIPTION
-        Without any parameters, this function will return the base appliance schema object which among other things include the list of supported WAPI versions and object types. Providing an -ObjectType will return the schema object for that type which among other things includes the list of supported fields and how they may be queried.
+        Without any parameters, this function will return the base appliance schema object which includes the list of supported WAPI versions and object types. Providing an -ObjectType will return the schema object for that type which includes a list of supported fields and functions.
 
     .PARAMETER ObjectType
-        Object type string. (e.g. network, record:host, range)
+        Object type string. (e.g. network, record:host, range). Partial names and wildcards are supported. If the ObjectType parameter would match multiple objects, the list of matching objects will be returned.
 
     .PARAMETER Raw
         If set, the schema object will be returned as-is rather than pretty printing the output. All parameters except -ObjectType will be ignored.
 
     .PARAMETER Fields
-        A list of Field names to include in the output. Wildcards are supported. If not specified, all Fields will be included.
+        A list of Field names to include in the output. Wildcards are supported. This parameter is ignored if -NoFields is specified. If neither is specified, all Fields will be included.
 
     .PARAMETER Operations
         A list of supported operation codes: r (read), w (write/create), u (update/set), s (search), d (delete). Only the Fields supporting at least one of these operations will be included in the output. If not specified, all Fields will be included.
+
+    .PARAMETER NoFields
+        If set, the object's fields will not be included in the output.
+
+    .PARAMETER Functions
+        A list of Function names to include in the output. Wildcards are supported. This parameter is ignored if -NoFunctions is specified. If neither is specified, all Functions will be included.
+
+    .PARAMETER NoFunctions
+        If set, the object's functions will not be included in the output.
 
     .PARAMETER WAPIHost
         The fully qualified DNS name or IP address of the Infoblox WAPI endpoint (usually the grid master). This parameter is required if not already set using Set-IBWAPIConfig.
@@ -346,12 +357,27 @@ function Get-IBSchema {
     .EXAMPLE
         Get-IBSchema
 
-        Get the root schema object
+        Get the root schema object.
 
     .EXAMPLE
         Get-IBSchema record:host
 
-        Get the schema object for the record:host type.
+        Get the record:host schema object.
+
+    .EXAMPLE
+        Get-IBSchema record:host -Raw
+
+        Get the record:host schema object in raw object form.
+
+    .EXAMPLE
+        Get-IBSchema grid -Fields enable*,name
+
+        Get the grid schema object and only include the name field and fields that start with 'enable'.
+
+    .EXAMPLE
+        Get-IBSchema network -Operations s -NoFunctions
+
+        Get the network schema object and only include fields that are searchable and skip function definitions.
 
     .LINK
         Project: https://github.com/rmbolger/Posh-IBWAPI

--- a/Posh-IBWAPI/Public/Get-IBSchema.ps1
+++ b/Posh-IBWAPI/Public/Get-IBSchema.ps1
@@ -42,7 +42,7 @@ function Get-IBSchema {
         Write-Verbose "Set highest version: $($cfg.HighestVersion)"
 
         if ([Version]$cfg.HighestVersion -lt [Version]'1.7.5') {
-            throw "NIOS $($cfg.HighestVersion) doesn't support schema queries"
+            throw "NIOS WAPI $($cfg.HighestVersion) doesn't support schema queries"
         }
     }
 


### PR DESCRIPTION
The primary focus of this PR is the addition of `Get-IBSchema` which aims to be a Powershell alternative to the web-based WAPI docs and addresses issue #6. Think of it like `Get-Help` but for the Infoblox WAPI object model. There are a lot of options and I should probably write a dedicated wiki page on how to use it.

Schema querying also enables the `-ReturnAllFields` parameter for `Get-IBObject` which addresses issue #18. 