### PR TITLE
(GH-55) Fix Send-file Functionargs hashtable

### DIFF
--- a/Posh-IBWAPI/Public/Send-IBFile.ps1
+++ b/Posh-IBWAPI/Public/Send-IBFile.ps1
@@ -94,7 +94,7 @@ function Send-IBFile {
         }
 
         # add/update the token in the function args
-        $FunctionArgs.token = $token
+        $FunctionArgs["token"] = $token
 
         # finalize the upload with the actual requested function and arguments
         Write-Debug "Calling $FunctionName with associated arguments"


### PR DESCRIPTION
In send-file.ps1, at the very end of the script, the token value is assigned to a non-existent "token" property of "$functionargs".  The change that I made actually adds the token key value pair to the hashtable object associated with $functionargs