### PR TITLE
(GH-55) Fix Send-file null hashtable issue

### DIFF
--- a/Posh-IBWAPI/Public/Send-IBFile.ps1
+++ b/Posh-IBWAPI/Public/Send-IBFile.ps1
@@ -94,7 +94,7 @@ function Send-IBFile {
         }
 
         # add/update the token in the function args
-        $FunctionArgs["token"] = $token
+        $FunctionArgs.token = $token
 
         # finalize the upload with the actual requested function and arguments
         Write-Debug "Calling $FunctionName with associated arguments"

--- a/Posh-IBWAPI/Public/Send-IBFile.ps1
+++ b/Posh-IBWAPI/Public/Send-IBFile.ps1
@@ -18,7 +18,7 @@ function Send-IBFile {
         })]
         [string]$Path,
         [Alias('args')]
-        [hashtable]$FunctionArgs,
+        [hashtable]$FunctionArgs = @{},
         [Alias('_ref','ref','ObjectType','type')]
         [string]$ObjectRef = 'fileop',
         [switch]$OverrideTransferHost,
@@ -94,7 +94,7 @@ function Send-IBFile {
         }
 
         # add/update the token in the function args
-        $FunctionArgs.token = $token
+        $FunctionArgs["token"] = $token
 
         # finalize the upload with the actual requested function and arguments
         Write-Debug "Calling $FunctionName with associated arguments"


### PR DESCRIPTION
Modified pull request to address null hashtable issue.  You were right in regards to the the hashtable for functionArgs needing to be instantiated as an empty hashtable as part of the solution.  The change has been implemented.  Now it it works perfectly.