### PR TITLE
Add -NoSession option to disable session re-use

### DIFF
--- a/Posh-IBWAPI/Posh-IBWAPI.Format.ps1xml
+++ b/Posh-IBWAPI/Posh-IBWAPI.Format.ps1xml
@@ -13,6 +13,7 @@
                     <TableColumnHeader/>
                     <TableColumnHeader><Label>CredentialUser</Label></TableColumnHeader>
                     <TableColumnHeader/>
+                    <TableColumnHeader/>
                 </TableHeaders>
                 <TableRowEntries>
                     <TableRowEntry>
@@ -28,6 +29,7 @@
                                 </ScriptBlock>
                             </TableColumnItem>
                             <TableColumnItem><PropertyName>SkipCertificateCheck</PropertyName></TableColumnItem>
+                            <TableColumnItem><PropertyName>NoSession</PropertyName></TableColumnItem>
                         </TableColumnItems>
                     </TableRowEntry>
                 </TableRowEntries>

--- a/Posh-IBWAPI/Posh-IBWAPI.psd1
+++ b/Posh-IBWAPI/Posh-IBWAPI.psd1
@@ -35,7 +35,7 @@ PrivateData = @{
 
     PSData = @{
 
-        Prerelease = 'alpha1'
+        Prerelease = 'alpha2'
         Tags = 'Infoblox','IPAM','WAPI','REST','Linux','Mac'
         LicenseUri = 'https://github.com/rmbolger/Posh-IBWAPI/blob/main/LICENSE'
         ProjectUri = 'https://github.com/rmbolger/Posh-IBWAPI'

--- a/Posh-IBWAPI/Posh-IBWAPI.psd1
+++ b/Posh-IBWAPI/Posh-IBWAPI.psd1
@@ -1,7 +1,7 @@
 @{
 
 RootModule = 'Posh-IBWAPI.psm1'
-ModuleVersion = '4.1.0'
+ModuleVersion = '4.2.0'
 GUID = '1483924a-a8bd-446f-ba0a-25443bcec77e'
 Author = 'Ryan Bolger'
 Copyright = '(c) 2017-2022 Ryan Bolger. All rights reserved.'
@@ -35,16 +35,14 @@ PrivateData = @{
 
     PSData = @{
 
+        Prerelease = 'alpha1'
         Tags = 'Infoblox','IPAM','WAPI','REST','Linux','Mac'
         LicenseUri = 'https://github.com/rmbolger/Posh-IBWAPI/blob/main/LICENSE'
         ProjectUri = 'https://github.com/rmbolger/Posh-IBWAPI'
         ReleaseNotes = @'
-## 4.1.0 (2025-02-06)
+## 4.2.0-alpha1 (2025-06-23)
 
-* Added `-Inheritance` switch to `Get-IBObject` which requests WAPI to return inherited values for returned fields that support inheritance. This requires WAPI 2.10.2 or later.
-  * WARNING: Depending on the field, the structure of the field's data may be different than a non-inheritance request. Be sure to test both ways to understand the differences in your use-case.
-* Fixed a problem with BatchMode calls to `Get-IBObject` that wouldn't properly send the `-ProxySearch` flag to batched queries when specified.
-* Changed low level URL encoding method to use `[System.Uri]::EscapeDataString()` which removes the explicit dependency on System.Web that was needed in PowerShell 5.1.
+* Added `-NoSession` switch to `Set-IBConfig` and `Invoke-IBWAPI` which disables session re-use between WAPI calls.
 '@
 
     }

--- a/Posh-IBWAPI/Private/Export-IBConfig.ps1
+++ b/Posh-IBWAPI/Private/Export-IBConfig.ps1
@@ -39,6 +39,7 @@ function Export-IBConfig
             WAPIVersion          = $profiles.$profName.WAPIVersion
             Credential           = $null
             SkipCertificateCheck = $profiles.$profName.SkipCertificateCheck
+            NoSession            = $profiles.$profName.NoSession
         }
 
         if ($vaultCfg) {
@@ -93,6 +94,7 @@ function Export-IBConfig
                 $profRaw.Credential.Username  -ne $vaultProf.Credential.Username -or
                 $profRaw.Credential.Password  -ne $vaultProf.Credential.Password -or
                 $profRaw.SkipCertificateCheck -ne $vaultProf.SkipCertificateCheck -or
+                $profRaw.NoSession            -ne $vaultProf.NoSession -or
                 $profRaw.Current              -ne $vaultProf.Current
             ) {
 

--- a/Posh-IBWAPI/Private/Get-EnvProfile.ps1
+++ b/Posh-IBWAPI/Private/Get-EnvProfile.ps1
@@ -37,7 +37,7 @@ function Get-EnvProfile {
         Credential  = [pscredential]::new($env:IBWAPI_USERNAME,$secPass)
     }
 
-    # Check for optional skip cert check. Any value other than the explicit
+    # Check for optional SkipCertificateCheck. Any value other than the explicit
     # set of "no" strings will be treated as $true
     $falseStrings = 'False','0','No'
     if ($env:IBWAPI_SKIPCERTCHECK -and $env:IBWAPI_SKIPCERTCHECK -notin $falseStrings) {
@@ -46,7 +46,7 @@ function Get-EnvProfile {
         $prof.SkipCertificateCheck = $false
     }
 
-    # Check for optional skip cert check. Any value other than the explicit
+    # Check for optional NoSession check. Any value other than the explicit
     # set of "no" strings will be treated as $true
     $falseStrings = 'False','0','No'
     if ($env:IBWAPI_NOSESSION -and $env:IBWAPI_NOSESSION -notin $falseStrings) {

--- a/Posh-IBWAPI/Private/Get-EnvProfile.ps1
+++ b/Posh-IBWAPI/Private/Get-EnvProfile.ps1
@@ -46,5 +46,14 @@ function Get-EnvProfile {
         $prof.SkipCertificateCheck = $false
     }
 
+    # Check for optional skip cert check. Any value other than the explicit
+    # set of "no" strings will be treated as $true
+    $falseStrings = 'False','0','No'
+    if ($env:IBWAPI_NOSESSION -and $env:IBWAPI_NOSESSION -notin $falseStrings) {
+        $prof.NoSession = $true
+    } else {
+        $prof.NoSession = $false
+    }
+
     return $prof
 }

--- a/Posh-IBWAPI/Private/Get-ReadFieldsForType.ps1
+++ b/Posh-IBWAPI/Private/Get-ReadFieldsForType.ps1
@@ -6,7 +6,8 @@ function Get-ReadFieldsForType {
         [string]$WAPIHost,
         [string]$WAPIVersion,
         [PSCredential]$Credential,
-        [switch]$SkipCertificateCheck
+        [switch]$SkipCertificateCheck,
+        [switch]$NoSession
     )
 
     $opts = [hashtable]::new($PSBoundParameters)

--- a/Posh-IBWAPI/Private/HighestVer.ps1
+++ b/Posh-IBWAPI/Private/HighestVer.ps1
@@ -7,6 +7,7 @@ function HighestVer
         [Parameter(Mandatory)]
         [pscredential]$Credential,
         [switch]$SkipCertificateCheck,
+        [switch]$NoSession,
         [Parameter(ValueFromRemainingArguments=$true)]
         $ExtraParams
     )
@@ -19,6 +20,7 @@ function HighestVer
             WAPIVersion = '1.1'
             Credential = $Credential
             SkipCertificateCheck = $SkipCertificateCheck.IsPresent
+            NoSession = $NoSession.IsPresent
             ErrorAction = 'Stop'
         }
         $versions = (Invoke-IBWAPI -Query '?_schema' @opts).supported_versions

--- a/Posh-IBWAPI/Private/Import-IBConfig.ps1
+++ b/Posh-IBWAPI/Private/Import-IBConfig.ps1
@@ -46,6 +46,10 @@ function Import-IBConfig
                 WAPIVersion = $profRaw.WAPIVersion
                 Credential  = $profCred
                 SkipCertificateCheck = $profRaw.SkipCertificateCheck
+                NoSession   = $profRaw.NoSession
+            }
+            if (-not $profRaw.NoSession) {
+                $profiles.$profName.NoSession = $false
             }
 
             # set it as current if appropriate
@@ -88,12 +92,16 @@ function Import-IBConfig
                 WAPIVersion = $json.Profiles.$_.WAPIVersion
                 Credential  = $null
                 SkipCertificateCheck = $false
+                NoSession   = $false
             }
             if ('Credential' -in $json.Profiles.$_.PSObject.Properties.Name) {
                 $profiles.$_.Credential = (Import-IBCred $json.Profiles.$_.Credential $_)
             }
             if ($json.Profiles.$_.SkipCertificateCheck) {
                 $profiles.$_.SkipCertificateCheck = $true
+            }
+            if ($json.Profiles.$_.NoSession) {
+                $profiles.$_.NoSession = $true
             }
         }
     }

--- a/Posh-IBWAPI/Private/Initialize-CallVars.ps1
+++ b/Posh-IBWAPI/Private/Initialize-CallVars.ps1
@@ -8,6 +8,7 @@ function Initialize-CallVars
         [string]$WAPIVersion,
         [PSCredential]$Credential,
         [switch]$SkipCertificateCheck,
+        [switch]$NoSession,
         [string]$ProfileName,
         [Parameter(ValueFromRemainingArguments=$true)]
         $ExtraParams
@@ -24,10 +25,10 @@ function Initialize-CallVars
     # - Explicit params override implicit and explicit profile params.
 
     # Remove any non-connection related parameters we were passed
-    $connParams = 'WAPIHost','WAPIVersion','Credential','SkipCertificateCheck'
+    $connParams = 'WAPIHost','WAPIVersion','Credential','SkipCertificateCheck','NoSession'
     foreach ($key in @($psb.Keys)) {
         if ($key -notin $connParams) {
-            $psb.Remove($key) | Out-Null
+            $null = $psb.Remove($key)
         }
     }
 
@@ -83,6 +84,14 @@ function Initialize-CallVars
     } else {
         # use the saved value
         $psb.SkipCertificateCheck = $prof.SkipCertificateCheck
+    }
+
+    # deal with NoSession
+    if ('NoSession' -in $psb.Keys) {
+        Write-Debug "Overriding saved NoSession with $($psb.NoSession.IsPresent)"
+    } else {
+        # use the saved value
+        $psb.NoSession = $prof.NoSession
     }
 
     # return our modified PSBoundParameters

--- a/Posh-IBWAPI/Public/Get-IBConfig.ps1
+++ b/Posh-IBWAPI/Public/Get-IBConfig.ps1
@@ -19,7 +19,7 @@ function Get-IBConfig
             # return the current profile
             $profName = Get-CurrentProfile
             $p = [PSCustomObject]$profiles.$profName |
-                Select-Object @{L='ProfileName';E={$profName}},WAPIHost,WAPIVersion,Credential,SkipCertificateCheck
+                Select-Object @{L='ProfileName';E={$profName}},WAPIHost,WAPIVersion,Credential,SkipCertificateCheck,NoSession
             $p.PSObject.TypeNames.Insert(0,'PoshIBWAPI.IBConfig')
             return $p
 
@@ -28,7 +28,7 @@ function Get-IBConfig
             # return the selected profile if it exists
             if ($ProfileName -in $profiles.Keys) {
                 $p = [PSCustomObject]$profiles.$ProfileName |
-                    Select-Object @{L='ProfileName';E={$ProfileName}},WAPIHost,WAPIVersion,Credential,SkipCertificateCheck
+                    Select-Object @{L='ProfileName';E={$ProfileName}},WAPIHost,WAPIVersion,Credential,SkipCertificateCheck,NoSession
                 $p.PSObject.TypeNames.Insert(0,'PoshIBWAPI.IBConfig')
                 return $p
             } else {
@@ -42,7 +42,7 @@ function Get-IBConfig
         # list all configs
         foreach ($profName in ($profiles.Keys | Sort-Object)) {
             $p = [PSCustomObject]$profiles.$profName |
-                Select-Object @{L='ProfileName';E={$profName}},WAPIHost,WAPIVersion,Credential,SkipCertificateCheck
+                Select-Object @{L='ProfileName';E={$profName}},WAPIHost,WAPIVersion,Credential,SkipCertificateCheck,NoSession
             $p.PSObject.TypeNames.Insert(0,'PoshIBWAPI.IBConfig')
             Write-Output $p
         }

--- a/Posh-IBWAPI/Public/Get-IBObject.ps1
+++ b/Posh-IBWAPI/Public/Get-IBObject.ps1
@@ -49,7 +49,8 @@ function Get-IBObject
         [Alias('version')]
         [string]$WAPIVersion,
         [PSCredential]$Credential,
-        [switch]$SkipCertificateCheck
+        [switch]$SkipCertificateCheck,
+        [switch]$NoSession
     )
 
     Begin {

--- a/Posh-IBWAPI/Public/Get-IBSchema.ps1
+++ b/Posh-IBWAPI/Public/Get-IBSchema.ps1
@@ -21,7 +21,8 @@ function Get-IBSchema {
         [Alias('version')]
         [string]$WAPIVersion,
         [PSCredential]$Credential,
-        [switch]$SkipCertificateCheck
+        [switch]$SkipCertificateCheck,
+        [switch]$NoSession
     )
 
     # grab the variables we'll be using for our REST calls

--- a/Posh-IBWAPI/Public/Invoke-IBFunction.ps1
+++ b/Posh-IBWAPI/Public/Invoke-IBFunction.ps1
@@ -21,7 +21,8 @@ function Invoke-IBFunction
         [Alias('version')]
         [string]$WAPIVersion,
         [PSCredential]$Credential,
-        [switch]$SkipCertificateCheck
+        [switch]$SkipCertificateCheck,
+        [switch]$NoSession
     )
 
     Begin {

--- a/Posh-IBWAPI/Public/New-IBObject.ps1
+++ b/Posh-IBWAPI/Public/New-IBObject.ps1
@@ -24,7 +24,8 @@ function New-IBObject
         [Alias('version')]
         [string]$WAPIVersion,
         [PSCredential]$Credential,
-        [switch]$SkipCertificateCheck
+        [switch]$SkipCertificateCheck,
+        [switch]$NoSession
     )
 
     Begin {

--- a/Posh-IBWAPI/Public/Receive-IBFile.ps1
+++ b/Posh-IBWAPI/Public/Receive-IBFile.ps1
@@ -23,7 +23,8 @@ function Receive-IBFile {
         [Alias('version')]
         [string]$WAPIVersion,
         [PSCredential]$Credential,
-        [switch]$SkipCertificateCheck
+        [switch]$SkipCertificateCheck,
+        [switch]$NoSession
     )
 
     Begin {

--- a/Posh-IBWAPI/Public/Remove-IBObject.ps1
+++ b/Posh-IBWAPI/Public/Remove-IBObject.ps1
@@ -21,7 +21,8 @@ function Remove-IBObject
         [Alias('version')]
         [string]$WAPIVersion,
         [PSCredential]$Credential,
-        [switch]$SkipCertificateCheck
+        [switch]$SkipCertificateCheck,
+        [switch]$NoSession
     )
 
     Begin {

--- a/Posh-IBWAPI/Public/Send-IBFile.ps1
+++ b/Posh-IBWAPI/Public/Send-IBFile.ps1
@@ -33,7 +33,8 @@ function Send-IBFile {
         [Alias('version')]
         [string]$WAPIVersion,
         [PSCredential]$Credential,
-        [switch]$SkipCertificateCheck
+        [switch]$SkipCertificateCheck,
+        [switch]$NoSession
     )
 
     Begin {

--- a/Posh-IBWAPI/Public/Set-IBConfig.ps1
+++ b/Posh-IBWAPI/Public/Set-IBConfig.ps1
@@ -13,6 +13,7 @@ function Set-IBConfig
         [string]$WAPIVersion,
         [PSCredential]$Credential,
         [switch]$SkipCertificateCheck,
+        [switch]$NoSession,
         [ValidateScript({Test-NonEmptyString $_ -ThrowOnFail})]
         [string]$NewName,
         [switch]$NoSwitchProfile
@@ -92,6 +93,15 @@ function Set-IBConfig
         Write-Debug "SkipCertificateCheck set to $($cfg.SkipCertificateCheck)"
     } elseif (-not ('SkipCertificateCheck' -in $cfg.Keys)) {
         $cfg.SkipCertificateCheck = $false
+    }
+
+    # NoSession defaults to false, but can also be explicitly set to false
+    # so don't just assume it's true if the flag was specified.
+    if ('NoSession' -in $PSBoundParameters.Keys) {
+        $cfg.NoSession = $NoSession.IsPresent
+        Write-Debug "NoSession set to $($cfg.NoSession)"
+    } elseif (-not ('NoSession' -in $cfg.Keys)) {
+        $cfg.NoSession = $false
     }
 
     if ($WAPIVersion) {

--- a/Posh-IBWAPI/Public/Set-IBObject.ps1
+++ b/Posh-IBWAPI/Public/Set-IBObject.ps1
@@ -29,7 +29,8 @@ function Set-IBObject
         [Alias('version')]
         [string]$WAPIVersion,
         [PSCredential]$Credential,
-        [switch]$SkipCertificateCheck
+        [switch]$SkipCertificateCheck,
+        [switch]$NoSession
     )
 
     Begin {

--- a/Posh-IBWAPI/en-US/Posh-IBWAPI-help.xml
+++ b/Posh-IBWAPI/en-US/Posh-IBWAPI-help.xml
@@ -191,6 +191,17 @@
           <dev:defaultValue>False</dev:defaultValue>
         </command:parameter>
         <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
+          <maml:name>NoSession</maml:name>
+          <maml:description>
+            <maml:para>If set, no sessions will be saved or used for this call.</maml:para>
+          </maml:description>
+          <dev:type>
+            <maml:name>SwitchParameter</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>False</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
           <maml:name>ProfileName</maml:name>
           <maml:description>
             <maml:para>The name of a specific config profile to use instead of the currently active one.</maml:para>
@@ -345,6 +356,17 @@
             <maml:uri />
           </dev:type>
           <dev:defaultValue>2147483647</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
+          <maml:name>NoSession</maml:name>
+          <maml:description>
+            <maml:para>If set, no sessions will be saved or used for this call.</maml:para>
+          </maml:description>
+          <dev:type>
+            <maml:name>SwitchParameter</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>False</dev:defaultValue>
         </command:parameter>
         <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
           <maml:name>PageSize</maml:name>
@@ -506,6 +528,17 @@
           <maml:name>NoPaging</maml:name>
           <maml:description>
             <maml:para>If specified, automatic paging will not be used. This is occasionally necessary for some object type queries that return a single object reference such as dhcp:statistics.</maml:para>
+          </maml:description>
+          <dev:type>
+            <maml:name>SwitchParameter</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>False</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
+          <maml:name>NoSession</maml:name>
+          <maml:description>
+            <maml:para>If set, no sessions will be saved or used for this call.</maml:para>
           </maml:description>
           <dev:type>
             <maml:name>SwitchParameter</maml:name>
@@ -686,6 +719,18 @@
         <maml:name>NoPaging</maml:name>
         <maml:description>
           <maml:para>If specified, automatic paging will not be used. This is occasionally necessary for some object type queries that return a single object reference such as dhcp:statistics.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+        <dev:type>
+          <maml:name>SwitchParameter</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>False</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
+        <maml:name>NoSession</maml:name>
+        <maml:description>
+          <maml:para>If set, no sessions will be saved or used for this call.</maml:para>
         </maml:description>
         <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
         <dev:type>
@@ -1042,6 +1087,17 @@
           <dev:defaultValue>False</dev:defaultValue>
         </command:parameter>
         <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
+          <maml:name>NoSession</maml:name>
+          <maml:description>
+            <maml:para>If set, no sessions will be saved or used for this call.</maml:para>
+          </maml:description>
+          <dev:type>
+            <maml:name>SwitchParameter</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>False</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
           <maml:name>Raw</maml:name>
           <maml:description>
             <maml:para>If set, the schema object will be returned as-is rather than pretty printing the output. All additional display parameters are ignored except -LaunchHTML.</maml:para>
@@ -1142,6 +1198,18 @@
         <maml:name>NoFunctions</maml:name>
         <maml:description>
           <maml:para>If set, the object's functions will not be included in the output.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+        <dev:type>
+          <maml:name>SwitchParameter</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>False</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
+        <maml:name>NoSession</maml:name>
+        <maml:description>
+          <maml:para>If set, no sessions will be saved or used for this call.</maml:para>
         </maml:description>
         <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
         <dev:type>
@@ -1393,6 +1461,17 @@
           <dev:defaultValue>None</dev:defaultValue>
         </command:parameter>
         <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
+          <maml:name>NoSession</maml:name>
+          <maml:description>
+            <maml:para>If set, no sessions will be saved or used for this call.</maml:para>
+          </maml:description>
+          <dev:type>
+            <maml:name>SwitchParameter</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>False</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
           <maml:name>SkipCertificateCheck</maml:name>
           <maml:description>
             <maml:para>If set, SSL/TLS certificate validation will be disabled. Overrides value stored with Set-IBConfig.</maml:para>
@@ -1463,6 +1542,18 @@
           <maml:uri />
         </dev:type>
         <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
+        <maml:name>NoSession</maml:name>
+        <maml:description>
+          <maml:para>If set, no sessions will be saved or used for this call.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+        <dev:type>
+          <maml:name>SwitchParameter</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>False</dev:defaultValue>
       </command:parameter>
       <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName, ByValue)" position="1" aliases="_ref, ref">
         <maml:name>ObjectRef</maml:name>
@@ -2247,6 +2338,17 @@ $grid | Invoke-IBFunction -name restartservices -args $restartArgs</dev:code>
           </dev:type>
           <dev:defaultValue>False</dev:defaultValue>
         </command:parameter>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
+          <maml:name>NoSession</maml:name>
+          <maml:description>
+            <maml:para>If set, no sessions will be saved or used for this call.</maml:para>
+          </maml:description>
+          <dev:type>
+            <maml:name>SwitchParameter</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>False</dev:defaultValue>
+        </command:parameter>
         <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="base, ReturnBaseFields">
           <maml:name>ReturnBase</maml:name>
           <maml:description>
@@ -2353,6 +2455,18 @@ $grid | Invoke-IBFunction -name restartservices -args $restartArgs</dev:code>
           <maml:uri />
         </dev:type>
         <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
+        <maml:name>NoSession</maml:name>
+        <maml:description>
+          <maml:para>If set, no sessions will be saved or used for this call.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+        <dev:type>
+          <maml:name>SwitchParameter</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>False</dev:defaultValue>
       </command:parameter>
       <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="False" position="1" aliases="type">
         <maml:name>ObjectType</maml:name>
@@ -2646,6 +2760,17 @@ New-IBObject 'record:host' $myhost -ReturnField 'comment','configure_for_dns' -R
           <dev:defaultValue>None</dev:defaultValue>
         </command:parameter>
         <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
+          <maml:name>NoSession</maml:name>
+          <maml:description>
+            <maml:para>If set, no sessions will be saved or used for this call.</maml:para>
+          </maml:description>
+          <dev:type>
+            <maml:name>SwitchParameter</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>False</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
           <maml:name>OverrideTransferHost</maml:name>
           <maml:description>
             <maml:para>If set, the hostname in the transfer URL returned by WAPI will be overridden to match the original WAPIHost if they don't already match. The SkipCertificateCheck switch will also be updated to match the passed in value instead of always being set to true for the call.</maml:para>
@@ -2705,6 +2830,18 @@ New-IBObject 'record:host' $myhost -ReturnField 'comment','configure_for_dns' -R
           <maml:uri />
         </dev:type>
         <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
+        <maml:name>NoSession</maml:name>
+        <maml:description>
+          <maml:para>If set, no sessions will be saved or used for this call.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+        <dev:type>
+          <maml:name>SwitchParameter</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>False</dev:defaultValue>
       </command:parameter>
       <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="4" aliases="_ref, ref, ObjectType, type">
         <maml:name>ObjectRef</maml:name>
@@ -3039,6 +3176,17 @@ New-IBObject 'record:host' $myhost -ReturnField 'comment','configure_for_dns' -R
           <dev:defaultValue>False</dev:defaultValue>
         </command:parameter>
         <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
+          <maml:name>NoSession</maml:name>
+          <maml:description>
+            <maml:para>If set, no sessions will be saved or used for this call.</maml:para>
+          </maml:description>
+          <dev:type>
+            <maml:name>SwitchParameter</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>False</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
           <maml:name>SkipCertificateCheck</maml:name>
           <maml:description>
             <maml:para>If set, SSL/TLS certificate validation will be disabled. Overrides value stored with Set-IBConfig.</maml:para>
@@ -3121,6 +3269,18 @@ New-IBObject 'record:host' $myhost -ReturnField 'comment','configure_for_dns' -R
           <maml:uri />
         </dev:type>
         <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
+        <maml:name>NoSession</maml:name>
+        <maml:description>
+          <maml:para>If set, no sessions will be saved or used for this call.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+        <dev:type>
+          <maml:name>SwitchParameter</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>False</dev:defaultValue>
       </command:parameter>
       <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName, ByValue)" position="1" aliases="_ref, ref">
         <maml:name>ObjectRef</maml:name>
@@ -3319,6 +3479,17 @@ $hostsToDelete | Remove-IBObject</dev:code>
           </dev:type>
           <dev:defaultValue>@{}</dev:defaultValue>
         </command:parameter>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
+          <maml:name>NoSession</maml:name>
+          <maml:description>
+            <maml:para>If set, no sessions will be saved or used for this call.</maml:para>
+          </maml:description>
+          <dev:type>
+            <maml:name>SwitchParameter</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>False</dev:defaultValue>
+        </command:parameter>
         <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="_ref, ref, ObjectType, type">
           <maml:name>ObjectRef</maml:name>
           <maml:description>
@@ -3427,6 +3598,18 @@ $hostsToDelete | Remove-IBObject</dev:code>
           <maml:uri />
         </dev:type>
         <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
+        <maml:name>NoSession</maml:name>
+        <maml:description>
+          <maml:para>If set, no sessions will be saved or used for this call.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+        <dev:type>
+          <maml:name>SwitchParameter</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>False</dev:defaultValue>
       </command:parameter>
       <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="_ref, ref, ObjectType, type">
         <maml:name>ObjectRef</maml:name>
@@ -3857,6 +4040,17 @@ $hostsToDelete | Remove-IBObject</dev:code>
           <dev:defaultValue>None</dev:defaultValue>
         </command:parameter>
         <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
+          <maml:name>NoSession</maml:name>
+          <maml:description>
+            <maml:para>If set, no sessions will be saved or used for this call.</maml:para>
+          </maml:description>
+          <dev:type>
+            <maml:name>SwitchParameter</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>False</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
           <maml:name>ProfileName</maml:name>
           <maml:description>
             <maml:para>The name of a specific config profile to use instead of the currently active one.</maml:para>
@@ -3985,6 +4179,17 @@ $hostsToDelete | Remove-IBObject</dev:code>
             <maml:uri />
           </dev:type>
           <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
+          <maml:name>NoSession</maml:name>
+          <maml:description>
+            <maml:para>If set, no sessions will be saved or used for this call.</maml:para>
+          </maml:description>
+          <dev:type>
+            <maml:name>SwitchParameter</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>False</dev:defaultValue>
         </command:parameter>
         <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName, ByValue)" position="named" aliases="_ref, ref">
           <maml:name>ObjectRef</maml:name>
@@ -4152,6 +4357,18 @@ $hostsToDelete | Remove-IBObject</dev:code>
           <maml:uri />
         </dev:type>
         <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
+        <maml:name>NoSession</maml:name>
+        <maml:description>
+          <maml:para>If set, no sessions will be saved or used for this call.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+        <dev:type>
+          <maml:name>SwitchParameter</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>False</dev:defaultValue>
       </command:parameter>
       <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName, ByValue)" position="named" aliases="_ref, ref">
         <maml:name>ObjectRef</maml:name>

--- a/Posh-IBWAPI/en-US/Posh-IBWAPI-help.xml
+++ b/Posh-IBWAPI/en-US/Posh-IBWAPI-help.xml
@@ -1689,6 +1689,17 @@ $grid | Invoke-IBFunction -name restartservices -args $restartArgs</dev:code>
           <dev:defaultValue>Get</dev:defaultValue>
         </command:parameter>
         <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
+          <maml:name>NoSession</maml:name>
+          <maml:description>
+            <maml:para>If set, session related parameters will be ignored and no sessions will be saved or used for this call.</maml:para>
+          </maml:description>
+          <dev:type>
+            <maml:name>SwitchParameter</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>False</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
           <maml:name>OutFile</maml:name>
           <maml:description>
             <maml:para>Specifies the output file that this cmdlet saves the response body. Enter a path and file name. If you omit the path, the default is the current location.</maml:para>
@@ -1833,6 +1844,17 @@ $grid | Invoke-IBFunction -name restartservices -args $restartArgs</dev:code>
           <dev:defaultValue>Get</dev:defaultValue>
         </command:parameter>
         <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
+          <maml:name>NoSession</maml:name>
+          <maml:description>
+            <maml:para>If set, session related parameters will be ignored and no sessions will be saved or used for this call.</maml:para>
+          </maml:description>
+          <dev:type>
+            <maml:name>SwitchParameter</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>False</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
           <maml:name>OutFile</maml:name>
           <maml:description>
             <maml:para>Specifies the output file that this cmdlet saves the response body. Enter a path and file name. If you omit the path, the default is the current location.</maml:para>
@@ -1951,6 +1973,18 @@ $grid | Invoke-IBFunction -name restartservices -args $restartArgs</dev:code>
           <maml:uri />
         </dev:type>
         <dev:defaultValue>Get</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
+        <maml:name>NoSession</maml:name>
+        <maml:description>
+          <maml:para>If set, session related parameters will be ignored and no sessions will be saved or used for this call.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+        <dev:type>
+          <maml:name>SwitchParameter</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>False</dev:defaultValue>
       </command:parameter>
       <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
         <maml:name>OutFile</maml:name>
@@ -3582,6 +3616,17 @@ $hostsToDelete | Remove-IBObject</dev:code>
           <dev:defaultValue>None</dev:defaultValue>
         </command:parameter>
         <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
+          <maml:name>NoSession</maml:name>
+          <maml:description>
+            <maml:para>When set, disables session use for this profile which causes explicit credentials to be sent with every call. This can decrease performance and cause extra audit logging against the WAPI endpoint, but may be desired in rare cases.</maml:para>
+          </maml:description>
+          <dev:type>
+            <maml:name>SwitchParameter</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>False</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
           <maml:name>NoSwitchProfile</maml:name>
           <maml:description>
             <maml:para>If set, the current profile will not switch to the specified -ProfileName if different.</maml:para>
@@ -3629,6 +3674,18 @@ $hostsToDelete | Remove-IBObject</dev:code>
           <maml:uri />
         </dev:type>
         <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
+        <maml:name>NoSession</maml:name>
+        <maml:description>
+          <maml:para>When set, disables session use for this profile which causes explicit credentials to be sent with every call. This can decrease performance and cause extra audit logging against the WAPI endpoint, but may be desired in rare cases.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+        <dev:type>
+          <maml:name>SwitchParameter</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>False</dev:defaultValue>
       </command:parameter>
       <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
         <maml:name>NoSwitchProfile</maml:name>

--- a/Tests/Export-IBConfig.Tests.ps1
+++ b/Tests/Export-IBConfig.Tests.ps1
@@ -20,6 +20,7 @@ Describe "Export-IBConfig" {
             WAPIVersion = '1.0'
             Credential = $fakeCred1
             SkipCertificateCheck = $false
+            NoSession = $true
         }
 
         $fakePass2 = ConvertTo-SecureString 'password2' -AsPlainText -Force
@@ -29,6 +30,7 @@ Describe "Export-IBConfig" {
             WAPIVersion = '2.0'
             Credential = $fakeCred2
             SkipCertificateCheck = $true
+            NoSession = $false
         }
 
         $fakeVaultConfig = @{
@@ -43,6 +45,7 @@ Describe "Export-IBConfig" {
                 Password = 'password1'
             }
             SkipCertificateCheck = $false
+            NoSession = $true
             Current = $true
         }
         $fakeVaultProfile2 = @{
@@ -53,6 +56,7 @@ Describe "Export-IBConfig" {
                 Password = 'password2'
             }
             SkipCertificateCheck = $true
+            NoSession = $false
             Current = $false
         }
     }
@@ -122,6 +126,7 @@ Describe "Export-IBConfig" {
                 $prof.WAPIHost    | Should -Be 'gm1'
                 $prof.WAPIVersion | Should -Be '1.0'
                 $prof.SkipCertificateCheck | Should -BeFalse
+                $prof.NoSession | Should -BeTrue
                 $prof.Credential.Username | Should -Be 'admin1'
                 if ($IsWindows -or (-not $PSEdition) -or $PSEdition -eq 'Desktop') {
                     $secPass = $prof.Credential.Password | ConvertTo-SecureString
@@ -246,6 +251,7 @@ Describe "Export-IBConfig" {
                 $prof.WAPIHost    | Should -Be 'gm1'
                 $prof.WAPIVersion | Should -Be '1.0'
                 $prof.SkipCertificateCheck | Should -BeFalse
+                $prof.NoSession | Should -BeTrue
                 $prof.Credential.Username | Should -Be 'admin1'
                 if ($IsWindows -or (-not $PSEdition) -or $PSEdition -eq 'Desktop') {
                     $secPass = $prof.Credential.Password | ConvertTo-SecureString
@@ -316,6 +322,7 @@ Describe "Export-IBConfig" {
                 $prof1.WAPIHost    | Should -Be 'gm1'
                 $prof1.WAPIVersion | Should -Be '1.0'
                 $prof1.SkipCertificateCheck | Should -BeFalse
+                $prof1.NoSession | Should -BeTrue
                 $prof1.Credential.Username | Should -Be 'admin1'
                 if ($IsWindows -or (-not $PSEdition) -or $PSEdition -eq 'Desktop') {
                     $secPass = $prof1.Credential.Password | ConvertTo-SecureString
@@ -332,6 +339,7 @@ Describe "Export-IBConfig" {
                 $prof2.WAPIHost    | Should -Be 'gm2'
                 $prof2.WAPIVersion | Should -Be '2.0'
                 $prof2.SkipCertificateCheck | Should -BeTrue
+                $prof2.NoSession | Should -BeFalse
                 $prof2.Credential.Username | Should -Be 'admin2'
                 if ($IsWindows -or (-not $PSEdition) -or $PSEdition -eq 'Desktop') {
                     $secPass = $prof2.Credential.Password | ConvertTo-SecureString

--- a/Tests/Get-IBConfig.Tests.ps1
+++ b/Tests/Get-IBConfig.Tests.ps1
@@ -13,6 +13,7 @@ Describe "Get-IBConfig" {
             WAPIVersion = '1.0'
             Credential = $fakeCred1
             SkipCertificateCheck = $false
+            NoSession = $true
         }
 
         $fakePass2 = ConvertTo-SecureString 'password2' -AsPlainText -Force
@@ -22,6 +23,7 @@ Describe "Get-IBConfig" {
             WAPIVersion = '2.0'
             Credential = $fakeCred2
             SkipCertificateCheck = $true
+            NoSession = $false
         }
     }
 
@@ -59,6 +61,7 @@ Describe "Get-IBConfig" {
             $config.WAPIVersion          | Should -Be '1.0'
             $config.Credential           | Should -Be $fakeCred1
             $config.SkipCertificateCheck | Should -BeFalse
+            $config.NoSession            | Should -BeTrue
         }
 
         It "Returns the profile with specific profile name" {
@@ -70,6 +73,7 @@ Describe "Get-IBConfig" {
             $config.WAPIVersion          | Should -Be '1.0'
             $config.Credential           | Should -Be $fakeCred1
             $config.SkipCertificateCheck | Should -BeFalse
+            $config.NoSession            | Should -BeTrue
         }
 
         It "Returns null with wrong profile name" {
@@ -85,6 +89,7 @@ Describe "Get-IBConfig" {
             $configs.WAPIVersion          | Should -Be '1.0'
             $configs.Credential           | Should -Be $fakeCred1
             $configs.SkipCertificateCheck | Should -BeFalse
+            $configs.NoSession            | Should -BeTrue
         }
     }
 
@@ -107,6 +112,7 @@ Describe "Get-IBConfig" {
             $config.WAPIVersion          | Should -Be '1.0'
             $config.Credential           | Should -Be $fakeCred1
             $config.SkipCertificateCheck | Should -BeFalse
+            $config.NoSession            | Should -BeTrue
         }
 
         It "Returns null with wrong profile name" {
@@ -122,6 +128,7 @@ Describe "Get-IBConfig" {
             $configs.WAPIVersion          | Should -Be '1.0'
             $configs.Credential           | Should -Be $fakeCred1
             $configs.SkipCertificateCheck | Should -BeFalse
+            $configs.NoSession            | Should -BeTrue
         }
     }
 
@@ -143,6 +150,7 @@ Describe "Get-IBConfig" {
             $config.WAPIVersion          | Should -Be '1.0'
             $config.Credential           | Should -Be $fakeCred1
             $config.SkipCertificateCheck | Should -BeFalse
+            $config.NoSession            | Should -BeTrue
         }
 
         It "Returns another profile with specific profile name" {
@@ -154,6 +162,7 @@ Describe "Get-IBConfig" {
             $config.WAPIVersion          | Should -Be '2.0'
             $config.Credential           | Should -Be $fakeCred2
             $config.SkipCertificateCheck | Should -BeTrue
+            $config.NoSession            | Should -BeFalse
         }
 
         It "Returns null with wrong profile name" {
@@ -170,6 +179,7 @@ Describe "Get-IBConfig" {
             $configs[0].WAPIVersion          | Should -Be '1.0'
             $configs[0].Credential           | Should -Be $fakeCred1
             $configs[0].SkipCertificateCheck | Should -BeFalse
+            $configs[0].NoSession            | Should -BeTrue
             $configs[1]                      | Should -Not -BeNullOrEmpty
             $configs[1].PSTypeNames          | Should -Contain PoshIBWAPI.IBConfig
             $configs[1].ProfileName          | Should -Be 'prof2'
@@ -177,6 +187,7 @@ Describe "Get-IBConfig" {
             $configs[1].WAPIVersion          | Should -Be '2.0'
             $configs[1].Credential           | Should -Be $fakeCred2
             $configs[1].SkipCertificateCheck | Should -BeTrue
+            $configs[1].NoSession            | Should -BeFalse
         }
     }
 }

--- a/Tests/Initialize-CallVars.Tests.ps1
+++ b/Tests/Initialize-CallVars.Tests.ps1
@@ -21,6 +21,7 @@ Describe "Initialize-CallVars" {
             WAPIVersion = '1.0'
             Credential = $cred1
             SkipCertificateCheck = $false
+            NoSession = $true
         }
         $pass2 = ConvertTo-SecureString 'pass2' -AsPlainText -Force
         $cred2 = New-Object PSCredential 'admin2',$pass2
@@ -29,6 +30,7 @@ Describe "Initialize-CallVars" {
             WAPIVersion = '2.0'
             Credential = $cred2
             SkipCertificateCheck = $true
+            NoSession = $false
         }
     }
 
@@ -54,6 +56,8 @@ Describe "Initialize-CallVars" {
             @{ splat = @{ WAPIHost='gm2'; WAPIVersion='2.0'; Credential=$cred2 } }
             @{ splat = @{ WAPIHost='gm2'; WAPIVersion='2.0'; Credential=$cred2; SkipCertificateCheck=$true } }
             @{ splat = @{ WAPIHost='gm2'; WAPIVersion='2.0'; Credential=$cred2; SkipCertificateCheck=$false } }
+            @{ splat = @{ WAPIHost='gm2'; WAPIVersion='2.0'; Credential=$cred2; NoSession=$true } }
+            @{ splat = @{ WAPIHost='gm2'; WAPIVersion='2.0'; Credential=$cred2; NoSession=$false } }
             @{ splat = @{ WAPIHost='gm2'; WAPIVersion='2.0'; Credential=$cred2; ProfileName='noexist' } }
         ) {
             InModuleScope Posh-IBWAPI -Parameters @{Splat=$splat} {
@@ -65,6 +69,7 @@ Describe "Initialize-CallVars" {
                 $result.WAPIVersion            | Should -Be $Splat.WAPIVersion
                 $result.Credential.Username    | Should -Be $Splat.Credential.Username
                 $result.SkipCertificateCheck   | Should -Be $Splat.SkipCertificateCheck
+                $result.NoSession              | Should -Be $Splat.NoSession
             }
         }
     }
@@ -91,6 +96,8 @@ Describe "Initialize-CallVars" {
             @{ splat = @{ WAPIHost='gm2'; WAPIVersion='2.0'; Credential=$cred2; ProfileName='noexist' } }
             @{ splat = @{ WAPIHost='gm2'; WAPIVersion='2.0'; Credential=$cred2; SkipCertificateCheck=$true; ProfileName='noexist' } }
             @{ splat = @{ WAPIHost='gm2'; WAPIVersion='2.0'; Credential=$cred2; SkipCertificateCheck=$false; ProfileName='noexist' } }
+            @{ splat = @{ WAPIHost='gm2'; WAPIVersion='2.0'; Credential=$cred2; NoSession=$true; ProfileName='noexist' } }
+            @{ splat = @{ WAPIHost='gm2'; WAPIVersion='2.0'; Credential=$cred2; NoSession=$false; ProfileName='noexist' } }
         ) {
             InModuleScope Posh-IBWAPI -Parameters @{Splat=$splat} {
                 param ($Splat)
@@ -100,6 +107,7 @@ Describe "Initialize-CallVars" {
                 $result.WAPIVersion            | Should -Be $Splat.WAPIVersion
                 $result.Credential.Username    | Should -Be $Splat.Credential.Username
                 $result.SkipCertificateCheck   | Should -Be $Splat.SkipCertificateCheck
+                $result.NoSession              | Should -Be $Splat.NoSession
             }
         }
 
@@ -109,6 +117,7 @@ Describe "Initialize-CallVars" {
             @{ splat = @{ WAPIVersion='2.0' } }
             @{ splat = @{ Credential=$cred2 } }
             @{ splat = @{ SkipCertificateCheck = $true } }
+            @{ splat = @{ NoSession = $false } }
         ) {
             InModuleScope Posh-IBWAPI -Parameters @{Splat=$splat} {
                 param($Splat)
@@ -134,6 +143,9 @@ Describe "Initialize-CallVars" {
                 if ('SkipCertificateCheck' -notin $Splat.Keys) {
                     $result.SkipCertificateCheck | Should -BeFalse
                 }
+                if ('NoSession' -notin $Splat.Keys) {
+                    $result.NoSession | Should -BeTrue
+                }
             }
         }
     }
@@ -151,6 +163,7 @@ Describe "Initialize-CallVars" {
             @{ splat = @{ WAPIVersion='3.0'; ProfileName='prof2' } }
             @{ splat = @{ Credential=$cred3; ProfileName='prof2' } }
             @{ splat = @{ SkipCertificateCheck=$false; ProfileName='prof2' } }
+            @{ splat = @{ NoSession=$true; ProfileName='prof2' } }
         ) {
             InModuleScope Posh-IBWAPI -Parameters @{Splat=$splat} {
                 param ($Splat)
@@ -174,6 +187,9 @@ Describe "Initialize-CallVars" {
                 }
                 if ('SkipCertificateCheck' -notin $Splat.Keys) {
                     $result.SkipCertificateCheck | Should -BeTrue
+                }
+                if ('NoSession' -notin $Splat.Keys) {
+                    $result.NoSession | Should -BeFalse
                 }
             }
         }

--- a/Tests/Set-IBConfig.Tests.ps1
+++ b/Tests/Set-IBConfig.Tests.ps1
@@ -53,11 +53,12 @@ Describe "Set-IBConfig" {
         $config.WAPIVersion          | Should -Be '1.0'
         $config.Credential.Username  | Should -Be 'admin1'
         $config.SkipCertificateCheck | Should -BeFalse
+        $config.NoSession            | Should -BeFalse
     }
 
     It "Writes second profile with all values specified" {
 
-        Set-IBConfig -ProfileName 'prof2' -WAPIHost 'gm2' -WAPIVersion '2.0' -Credential $fakeCred2 -SkipCertificateCheck
+        Set-IBConfig -ProfileName 'prof2' -WAPIHost 'gm2' -WAPIVersion '2.0' -Credential $fakeCred2 -SkipCertificateCheck -NoSession
 
         # make sure active profile is the one we just set
         $config = Get-IBConfig
@@ -68,6 +69,7 @@ Describe "Set-IBConfig" {
         $config.WAPIVersion          | Should -Be '2.0'
         $config.Credential.Username  | Should -Be 'admin2'
         $config.SkipCertificateCheck | Should -BeTrue
+        $config.NoSession            | Should -BeTrue
 
         # make sure original profile still exists
         $config = Get-IBConfig -ProfileName 'prof1'
@@ -78,6 +80,7 @@ Describe "Set-IBConfig" {
         $config.WAPIVersion          | Should -Be '1.0'
         $config.Credential.Username  | Should -Be 'admin1'
         $config.SkipCertificateCheck | Should -BeFalse
+        $config.NoSession            | Should -BeFalse
     }
 
     It "It obeys NoSwitchProfile flag" {
@@ -93,6 +96,7 @@ Describe "Set-IBConfig" {
         $config.WAPIVersion          | Should -Be '2.0'
         $config.Credential.Username  | Should -Be 'admin2'
         $config.SkipCertificateCheck | Should -BeTrue
+        $config.NoSession            | Should -BeTrue
 
         # prof1 profile should have updated version
         $config = Get-IBConfig -ProfileName 'prof1'
@@ -127,6 +131,7 @@ Describe "Set-IBConfig" {
         $config.WAPIVersion          | Should -Be '1.11'
         $config.Credential.Username  | Should -Be 'admin1'
         $config.SkipCertificateCheck | Should -BeFalse
+        $config.NoSession            | Should -BeFalse
     }
 
     It "Can set individual value on the active profile" {
@@ -142,6 +147,9 @@ Describe "Set-IBConfig" {
 
         Set-IBConfig -SkipCertificateCheck
         (Get-IBConfig).SkipCertificateCheck | Should -BeTrue
+
+        Set-IBConfig -NoSession
+        (Get-IBConfig).NoSession | Should -BeTrue
     }
 
     It "Can use 'latest' for WAPIVersion" {

--- a/docs/Functions/Get-IBObject.md
+++ b/docs/Functions/Get-IBObject.md
@@ -17,7 +17,7 @@ Retrieve objects from the Infoblox database.
 ```powershell
 Get-IBObject [-ObjectType] <String> [-Filter <Object>] [-MaxResults <Int32>] [-PageSize <Int32>]
  [-ReturnField <String[]>] [-ReturnBase] [-ReturnAll] [-ProxySearch] [-Inheritance] [-ProfileName <String>]
- [-WAPIHost <String>] [-WAPIVersion <String>] [-Credential <PSCredential>] [-SkipCertificateCheck]
+ [-WAPIHost <String>] [-WAPIVersion <String>] [-Credential <PSCredential>] [-SkipCertificateCheck] [-NoSession]
  [<CommonParameters>]
 ```
 
@@ -25,14 +25,14 @@ Get-IBObject [-ObjectType] <String> [-Filter <Object>] [-MaxResults <Int32>] [-P
 ```powershell
 Get-IBObject [-ObjectType] <String> [-Filter <Object>] [-NoPaging] [-ReturnField <String[]>] [-ReturnBase]
  [-ReturnAll] [-ProxySearch] [-Inheritance] [-ProfileName <String>] [-WAPIHost <String>]
- [-WAPIVersion <String>] [-Credential <PSCredential>] [-SkipCertificateCheck] [<CommonParameters>]
+ [-WAPIVersion <String>] [-Credential <PSCredential>] [-SkipCertificateCheck] [-NoSession] [<CommonParameters>]
 ```
 
 ### ByRef
 ```powershell
 Get-IBObject [-ObjectRef] <String> [-ReturnField <String[]>] [-ReturnBase] [-ReturnAll] [-BatchMode]
  [-BatchGroupSize <Int32>] [-ProxySearch] [-Inheritance] [-ProfileName <String>] [-WAPIHost <String>]
- [-WAPIVersion <String>] [-Credential <PSCredential>] [-SkipCertificateCheck] [<CommonParameters>]
+ [-WAPIVersion <String>] [-Credential <PSCredential>] [-SkipCertificateCheck] [-NoSession] [<CommonParameters>]
 ```
 
 ## Description
@@ -182,6 +182,21 @@ Aliases:
 Required: False
 Position: Named
 Default value: False
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -NoSession
+If set, no sessions will be saved or used for this call.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
 Accept pipeline input: False
 Accept wildcard characters: False
 ```

--- a/docs/Functions/Get-IBSchema.md
+++ b/docs/Functions/Get-IBSchema.md
@@ -17,7 +17,7 @@ Query the schema of an object or the base appliance.
 Get-IBSchema [[-ObjectType] <String>] [-Raw] [-LaunchHTML] [[-Fields] <String[]>] [[-Operations] <String[]>]
  [-NoFields] [[-Functions] <String[]>] [-NoFunctions] [-Detailed] [[-ProfileName] <String>]
  [[-WAPIHost] <String>] [[-WAPIVersion] <String>] [[-Credential] <PSCredential>] [-SkipCertificateCheck]
- [<CommonParameters>]
+ [-NoSession] [<CommonParameters>]
 ```
 
 ## Description
@@ -169,6 +169,21 @@ Aliases:
 Required: False
 Position: Named
 Default value: False
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -NoSession
+If set, no sessions will be saved or used for this call.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
 Accept pipeline input: False
 Accept wildcard characters: False
 ```

--- a/docs/Functions/Invoke-IBFunction.md
+++ b/docs/Functions/Invoke-IBFunction.md
@@ -16,7 +16,7 @@ Call a WAPI function
 ```powershell
 Invoke-IBFunction [-ObjectRef] <String> [-FunctionName] <String> [[-FunctionArgs] <PSObject>]
  [[-ProfileName] <String>] [[-WAPIHost] <String>] [[-WAPIVersion] <String>] [[-Credential] <PSCredential>]
- [-SkipCertificateCheck] [-WhatIf] [-Confirm] [<CommonParameters>]
+ [-SkipCertificateCheck] [-NoSession] [-WhatIf] [-Confirm] [<CommonParameters>]
 ```
 
 ## Description
@@ -77,6 +77,21 @@ Aliases: name
 
 Required: True
 Position: 2
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -NoSession
+If set, no sessions will be saved or used for this call.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
 Default value: None
 Accept pipeline input: False
 Accept wildcard characters: False

--- a/docs/Functions/Invoke-IBWAPI.md
+++ b/docs/Functions/Invoke-IBWAPI.md
@@ -17,15 +17,15 @@ Send a request to the Infoblox WAPI (REST API).
 ```powershell
 Invoke-IBWAPI [-Uri] <Uri> [-Method <WebRequestMethod>] [-Credential <PSCredential>] [-Body <Object>]
  [-ContentType <String>] [-OutFile <String>] [-SessionVariable <String>] [-WebSession <WebRequestSession>]
- [-SkipCertificateCheck] [-WhatIf] [-Confirm] [<CommonParameters>]
+ [-NoSession] [-SkipCertificateCheck] [-WhatIf] [-Confirm] [<CommonParameters>]
 ```
 
 ### HostVersion
 ```powershell
 Invoke-IBWAPI [-WAPIHost] <String> [-WAPIVersion] <String> [-Query] <String> [-Method <WebRequestMethod>]
  [-Credential <PSCredential>] [-Body <Object>] [-ContentType <String>] [-OutFile <String>]
- [-SessionVariable <String>] [-WebSession <WebRequestSession>] [-SkipCertificateCheck] [-WhatIf] [-Confirm]
- [<CommonParameters>]
+ [-SessionVariable <String>] [-WebSession <WebRequestSession>] [-NoSession] [-SkipCertificateCheck] [-WhatIf]
+ [-Confirm] [<CommonParameters>]
 ```
 
 ## Description
@@ -102,6 +102,21 @@ Accepted values: Default, Get, Head, Post, Put, Delete, Trace, Options, Merge, P
 Required: False
 Position: Named
 Default value: Get
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -NoSession
+If set, session related parameters will be ignored and no sessions will be saved or used for this call.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
 Accept pipeline input: False
 Accept wildcard characters: False
 ```

--- a/docs/Functions/New-IBObject.md
+++ b/docs/Functions/New-IBObject.md
@@ -16,7 +16,7 @@ Create an object in Infoblox.
 ```powershell
 New-IBObject [-ObjectType] <String> [-IBObject] <PSObject> [-ReturnField <String[]>] [-ReturnBase] [-BatchMode]
  [-BatchGroupSize <Int32>] [[-ProfileName] <String>] [[-WAPIHost] <String>] [[-WAPIVersion] <String>]
- [[-Credential] <PSCredential>] [-SkipCertificateCheck] [-WhatIf] [-Confirm] [<CommonParameters>]
+ [[-Credential] <PSCredential>] [-SkipCertificateCheck] [-NoSession] [-WhatIf] [-Confirm] [<CommonParameters>]
 ```
 
 ## Description
@@ -130,6 +130,21 @@ Required: True
 Position: 2
 Default value: None
 Accept pipeline input: True (ByValue)
+Accept wildcard characters: False
+```
+
+### -NoSession
+If set, no sessions will be saved or used for this call.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
 Accept wildcard characters: False
 ```
 

--- a/docs/Functions/Receive-IBFile.md
+++ b/docs/Functions/Receive-IBFile.md
@@ -16,7 +16,8 @@ Download a file from a fileop function
 ```powershell
 Receive-IBFile [-FunctionName] <String> [-OutFile] <String> [[-FunctionArgs] <IDictionary>]
  [[-ObjectRef] <String>] [-OverrideTransferHost] [[-ProfileName] <String>] [[-WAPIHost] <String>]
- [[-WAPIVersion] <String>] [[-Credential] <PSCredential>] [-SkipCertificateCheck] [<CommonParameters>]
+ [[-WAPIVersion] <String>] [[-Credential] <PSCredential>] [-SkipCertificateCheck] [-NoSession]
+ [<CommonParameters>]
 ```
 
 ## Description
@@ -83,6 +84,21 @@ Aliases: name
 
 Required: True
 Position: 1
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -NoSession
+If set, no sessions will be saved or used for this call.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
 Default value: None
 Accept pipeline input: False
 Accept wildcard characters: False

--- a/docs/Functions/Remove-IBObject.md
+++ b/docs/Functions/Remove-IBObject.md
@@ -16,7 +16,7 @@ Delete an object from Infoblox.
 ```powershell
 Remove-IBObject [-ObjectRef] <String> [[-DeleteArgs] <String[]>] [-BatchMode] [-BatchGroupSize <Int32>]
  [[-ProfileName] <String>] [[-WAPIHost] <String>] [[-WAPIVersion] <String>] [[-Credential] <PSCredential>]
- [-SkipCertificateCheck] [-WhatIf] [-Confirm] [<CommonParameters>]
+ [-SkipCertificateCheck] [-NoSession] [-WhatIf] [-Confirm] [<CommonParameters>]
 ```
 
 ## Description
@@ -100,6 +100,21 @@ Aliases: args
 
 Required: False
 Position: 2
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -NoSession
+If set, no sessions will be saved or used for this call.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
 Default value: None
 Accept pipeline input: False
 Accept wildcard characters: False

--- a/docs/Functions/Send-IBFile.md
+++ b/docs/Functions/Send-IBFile.md
@@ -16,7 +16,7 @@ Upload a file to Infoblox using one of the fileop upload functions.
 ```powershell
 Send-IBFile [-FunctionName] <String> [-Path] <String> [-FunctionArgs <IDictionary>] [-ObjectRef <String>]
  [-OverrideTransferHost] [-ProfileName <String>] [-WAPIHost <String>] [-WAPIVersion <String>]
- [-Credential <PSCredential>] [-SkipCertificateCheck] [<CommonParameters>]
+ [-Credential <PSCredential>] [-SkipCertificateCheck] [-NoSession] [<CommonParameters>]
 ```
 
 ## Description
@@ -75,6 +75,21 @@ Aliases: name
 
 Required: True
 Position: 1
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -NoSession
+If set, no sessions will be saved or used for this call.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
 Default value: None
 Accept pipeline input: False
 Accept wildcard characters: False

--- a/docs/Functions/Set-IBConfig.md
+++ b/docs/Functions/Set-IBConfig.md
@@ -15,7 +15,7 @@ Save connection parameters to a profile to avoid needing to supply them to futur
 
 ```powershell
 Set-IBConfig [[-ProfileName] <String>] [[-WAPIHost] <String>] [[-WAPIVersion] <String>]
- [[-Credential] <PSCredential>] [-SkipCertificateCheck] [[-NewName] <String>] [-NoSwitchProfile]
+ [[-Credential] <PSCredential>] [-SkipCertificateCheck] [-NoSession] [[-NewName] <String>] [-NoSwitchProfile]
  [<CommonParameters>]
 ```
 
@@ -78,6 +78,21 @@ Aliases:
 
 Required: False
 Position: 5
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -NoSession
+When set, disables session use for this profile which causes explicit credentials to be sent with every call. This can decrease performance and cause extra audit logging against the WAPI endpoint, but may be desired in rare cases.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
 Default value: None
 Accept pipeline input: False
 Accept wildcard characters: False

--- a/docs/Functions/Set-IBObject.md
+++ b/docs/Functions/Set-IBObject.md
@@ -17,14 +17,14 @@ Modify an object in Infoblox.
 ```powershell
 Set-IBObject -IBObject <PSObject> [-ReturnField <String[]>] [-ReturnBase] [-BatchMode]
  [-BatchGroupSize <Int32>] [-ProfileName <String>] [-WAPIHost <String>] [-WAPIVersion <String>]
- [-Credential <PSCredential>] [-SkipCertificateCheck] [-WhatIf] [-Confirm] [<CommonParameters>]
+ [-Credential <PSCredential>] [-SkipCertificateCheck] [-NoSession] [-WhatIf] [-Confirm] [<CommonParameters>]
 ```
 
 ### RefAndTemplate
 ```powershell
 Set-IBObject -ObjectRef <String> -TemplateObject <PSObject> [-ReturnField <String[]>] [-ReturnBase]
  [-BatchMode] [-BatchGroupSize <Int32>] [-ProfileName <String>] [-WAPIHost <String>] [-WAPIVersion <String>]
- [-Credential <PSCredential>] [-SkipCertificateCheck] [-WhatIf] [-Confirm] [<CommonParameters>]
+ [-Credential <PSCredential>] [-SkipCertificateCheck] [-NoSession] [-WhatIf] [-Confirm] [<CommonParameters>]
 ```
 
 ## Description
@@ -120,6 +120,21 @@ Required: True
 Position: Named
 Default value: None
 Accept pipeline input: True (ByValue)
+Accept wildcard characters: False
+```
+
+### -NoSession
+If set, no sessions will be saved or used for this call.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
 Accept wildcard characters: False
 ```
 


### PR DESCRIPTION
Adds a workaround for #68 by allowing users to disable session re-use using a `-NoSession` flag either via config profile and `Set-IBConfig` or on a per-call basis from the other public functions.